### PR TITLE
style(sonha_mdm): widen and wrap char/text columns in list views

### DIFF
--- a/sonha_mdm/static/src/css/style.css
+++ b/sonha_mdm/static/src/css/style.css
@@ -48,6 +48,24 @@ th.align-middle.cursor-default.opacity-trigger-hover {
     max-width: none !important;
 }
 
+/* Mở rộng và xuống dòng cho cột dữ liệu kiểu text/char trong list view */
+.o_list_view .o_data_row td.o_data_cell {
+    min-width: 140px;
+}
+
+.o_list_view .o_data_row td.o_data_cell .o_field_char,
+.o_list_view .o_data_row td.o_data_cell .o_field_text {
+    white-space: normal !important;
+    overflow-wrap: anywhere;
+    word-break: break-word;
+    line-height: 1.35;
+}
+
+.o_list_view table.o_list_table th[data-name],
+.o_list_view table.o_list_table td[data-name] {
+    max-width: 420px;
+}
+
 div[name="so_sanh_khach_hang"] div#ten_khachContainer {
     display: none;
 }
@@ -67,4 +85,3 @@ div[name="so_sanh_khach_hang"] div#mstContainer {
 div[name="so_sanh_khach_hang"] div#cccdContainer {
     display: none;
 }
-


### PR DESCRIPTION
### Motivation
- Improve readability of list views by widening columns that contain `char`/`text` values so longer values are easier to scan. 
- Ensure long text is visible by allowing values to wrap onto multiple lines instead of being truncated or staying on a single line.

### Description
- Updated `sonha_mdm/static/src/css/style.css` to add wrapping and sizing rules for list views. 
- Added a `min-width: 140px` for `.o_list_view .o_data_row td.o_data_cell` to give text/char columns more horizontal space. 
- Added wrapping rules (`white-space: normal !important`, `overflow-wrap: anywhere`, `word-break: break-word`, `line-height: 1.35`) for `.o_field_char` and `.o_field_text` so long values break into multiple lines. 
- Set a practical `max-width: 420px` for `th[data-name]` and `td[data-name]` in `.o_list_table` to balance readability and layout stability.

### Testing
- No automated tests were executed for this change because it is a CSS-only update.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f858bd700c832d8b4931814984e5e3)