### PR TITLE
Add standalone SonHa BOM Effect module with model and full views

### DIFF
--- a/sonha_bom_effect/__init__.py
+++ b/sonha_bom_effect/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/sonha_bom_effect/__manifest__.py
+++ b/sonha_bom_effect/__manifest__.py
@@ -1,0 +1,14 @@
+{
+    'name': 'SonHa BOM Effect',
+    'version': '1.0',
+    'summary': 'Quản lý định mức NVL theo TP/NVL effect-SAP',
+    'category': 'Inventory',
+    'license': 'LGPL-3',
+    'depends': ['base'],
+    'data': [
+        'security/ir.model.access.csv',
+        'views/sonha_bom_effect_views.xml',
+    ],
+    'installable': True,
+    'application': True,
+}

--- a/sonha_bom_effect/models/__init__.py
+++ b/sonha_bom_effect/models/__init__.py
@@ -1,0 +1,1 @@
+from . import sonha_bom_effect

--- a/sonha_bom_effect/models/sonha_bom_effect.py
+++ b/sonha_bom_effect/models/sonha_bom_effect.py
@@ -1,0 +1,17 @@
+from odoo import fields, models
+
+
+class SonhaBomEffect(models.Model):
+    _name = 'sonha.bom.effect'
+    _description = 'Định mức NVL effect/SAP'
+    _rec_name = 'product_name'
+
+    product_code = fields.Char(string='Mã TP effect/SAP', required=True, index=True)
+    product_name = fields.Char(string='Tên TP', required=True)
+    material_code = fields.Char(string='Mã NVL effect/SAP', required=True, index=True)
+    material_name = fields.Char(string='Tên NVL', required=True)
+    quantity_per_product = fields.Float(string='SL định mức/1 sản phẩm', digits=(16, 4), default=0.0)
+    thickness = fields.Float(string='Độ dày', digits=(16, 4))
+    roll_1 = fields.Char(string='Khổ 1')
+    roll_2 = fields.Char(string='Khổ 2')
+    unit = fields.Char(string='Đơn vị')

--- a/sonha_bom_effect/security/ir.model.access.csv
+++ b/sonha_bom_effect/security/ir.model.access.csv
@@ -1,0 +1,2 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_sonha_bom_effect_user,access_sonha_bom_effect_user,model_sonha_bom_effect,base.group_user,1,1,1,1

--- a/sonha_bom_effect/views/sonha_bom_effect_views.xml
+++ b/sonha_bom_effect/views/sonha_bom_effect_views.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_sonha_bom_effect_tree" model="ir.ui.view">
+        <field name="name">sonha.bom.effect.tree</field>
+        <field name="model">sonha.bom.effect</field>
+        <field name="arch" type="xml">
+            <list string="Định mức NVL effect/SAP" create="1" edit="1" delete="1">
+                <field name="product_code"/>
+                <field name="product_name"/>
+                <field name="material_code"/>
+                <field name="material_name"/>
+                <field name="quantity_per_product"/>
+                <field name="thickness"/>
+                <field name="roll_1"/>
+                <field name="roll_2"/>
+                <field name="unit"/>
+            </list>
+        </field>
+    </record>
+
+    <record id="view_sonha_bom_effect_form" model="ir.ui.view">
+        <field name="name">sonha.bom.effect.form</field>
+        <field name="model">sonha.bom.effect</field>
+        <field name="arch" type="xml">
+            <form string="Định mức NVL effect/SAP">
+                <sheet>
+                    <group>
+                        <group>
+                            <field name="product_code"/>
+                            <field name="product_name"/>
+                            <field name="material_code"/>
+                            <field name="material_name"/>
+                        </group>
+                        <group>
+                            <field name="quantity_per_product"/>
+                            <field name="thickness"/>
+                            <field name="roll_1"/>
+                            <field name="roll_2"/>
+                            <field name="unit"/>
+                        </group>
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <record id="view_sonha_bom_effect_search" model="ir.ui.view">
+        <field name="name">sonha.bom.effect.search</field>
+        <field name="model">sonha.bom.effect</field>
+        <field name="arch" type="xml">
+            <search string="Tìm định mức NVL effect/SAP">
+                <field name="product_code"/>
+                <field name="product_name"/>
+                <field name="material_code"/>
+                <field name="material_name"/>
+                <filter name="group_by_product_code" string="Nhóm theo mã TP" context="{'group_by': 'product_code'}"/>
+                <filter name="group_by_material_code" string="Nhóm theo mã NVL" context="{'group_by': 'material_code'}"/>
+            </search>
+        </field>
+    </record>
+
+    <record id="action_sonha_bom_effect" model="ir.actions.act_window">
+        <field name="name">Định mức NVL effect/SAP</field>
+        <field name="res_model">sonha.bom.effect</field>
+        <field name="view_mode">list,form</field>
+        <field name="search_view_id" ref="view_sonha_bom_effect_search"/>
+    </record>
+
+    <menuitem id="menu_sonha_bom_effect_root" name="Định mức NVL" sequence="10"/>
+    <menuitem id="menu_sonha_bom_effect" name="Định mức effect/SAP" parent="menu_sonha_bom_effect_root" action="action_sonha_bom_effect" sequence="1"/>
+</odoo>


### PR DESCRIPTION
### Motivation
- Provide an independent Odoo module to store and manage BOM effect data (product/material codes & names, quantity, thickness, roll widths, unit) so users can CRUD these records from the UI.

### Description
- Add new module `sonha_bom_effect` with a manifest that depends only on `base` and loads security and view files.
- Implement model `sonha.bom.effect` in `models/sonha_bom_effect.py` with fields `product_code`, `product_name`, `material_code`, `material_name`, `quantity_per_product`, `thickness`, `roll_1`, `roll_2`, and `unit`, and set `_rec_name` to `product_name`.
- Add full UI: list (tree) view, form view, search view with group filters, an action, and menu entries in `views/sonha_bom_effect_views.xml` for direct access.
- Add access control `security/ir.model.access.csv` granting CRUD permissions to internal users (`base.group_user`).

### Testing
- Inspected the created files (`__manifest__.py`, `models/sonha_bom_effect.py`, `views/sonha_bom_effect_views.xml`, `security/ir.model.access.csv`) via file-content listings and confirmed model fields and view definitions are present and match the requested fields (passed).
- Generated PR metadata with the repository helper tool to describe the new module and files (succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc4052d7788324b217fa3591b296da)