### PR TITLE
[sonha_mdm] Thêm wizard import Excel cho MDM Khách hàng với upsert theo Mã TG

### DIFF
--- a/sonha_mdm/__init__.py
+++ b/sonha_mdm/__init__.py
@@ -1,1 +1,2 @@
 from . import models
+from . import wizard

--- a/sonha_mdm/__manifest__.py
+++ b/sonha_mdm/__manifest__.py
@@ -35,6 +35,7 @@
         'views/mien_lon_views.xml',
         'views/mien_nho_views.xml',
         'data/cron_job.xml',
+        'wizard/mdm_khach_hang_import_wizard_views.xml',
         'views/menu_views.xml',
     ],
     'assets': {

--- a/sonha_mdm/models/mdm_khach_hang.py
+++ b/sonha_mdm/models/mdm_khach_hang.py
@@ -330,15 +330,6 @@ class MDMKhachHang(models.Model):
             self.env['ket.qua.khach.hang'].sudo().create(logs)
 
 
-    def action_open_import_wizard(self):
-        return {
-            'type': 'ir.actions.act_window',
-            'name': 'Import khách hàng từ Excel',
-            'res_model': 'mdm.khach.hang.import.wizard',
-            'view_mode': 'form',
-            'target': 'new',
-        }
-
     def action_open_update_popup(self):
         self.ensure_one()
 

--- a/sonha_mdm/models/mdm_khach_hang.py
+++ b/sonha_mdm/models/mdm_khach_hang.py
@@ -329,6 +329,16 @@ class MDMKhachHang(models.Model):
         if logs:
             self.env['ket.qua.khach.hang'].sudo().create(logs)
 
+
+    def action_open_import_wizard(self):
+        return {
+            'type': 'ir.actions.act_window',
+            'name': 'Import khách hàng từ Excel',
+            'res_model': 'mdm.khach.hang.import.wizard',
+            'view_mode': 'form',
+            'target': 'new',
+        }
+
     def action_open_update_popup(self):
         self.ensure_one()
 

--- a/sonha_mdm/security/ir.model.access.csv
+++ b/sonha_mdm/security/ir.model.access.csv
@@ -34,3 +34,4 @@ access_quan_huyen_cu,quan.huyen.cu,model_quan_huyen_cu,,1,1,1,1
 access_tinh_cu,tinh.cu,model_tinh_cu,,1,1,1,1
 access_mdm_plan,mdm.plan,model_mdm_plan,,1,1,1,1
 access_mien_nho,mien.nho,model_mien_nho,,1,1,1,1
+access_mdm_khach_hang_import_wizard,mdm.khach.hang.import.wizard,model_mdm_khach_hang_import_wizard,,1,1,1,1

--- a/sonha_mdm/views/mdm_khach_hang_views.xml
+++ b/sonha_mdm/views/mdm_khach_hang_views.xml
@@ -118,9 +118,6 @@
         <field name="model">mdm.khach.hang</field>
         <field name="arch" type="xml">
             <tree string="MDM khách hàng">
-                <header>
-                    <button name="action_open_import_wizard" type="object" string="Import Excel" class="btn-primary"/>
-                </header>
                 <field name="ma_khach"/>
                     <field name="ten_khach"/>
                     <field name="dia_chi_khach"/>

--- a/sonha_mdm/views/mdm_khach_hang_views.xml
+++ b/sonha_mdm/views/mdm_khach_hang_views.xml
@@ -118,6 +118,9 @@
         <field name="model">mdm.khach.hang</field>
         <field name="arch" type="xml">
             <tree string="MDM khách hàng">
+                <header>
+                    <button name="action_open_import_wizard" type="object" string="Import Excel" class="btn-primary"/>
+                </header>
                 <field name="ma_khach"/>
                     <field name="ten_khach"/>
                     <field name="dia_chi_khach"/>

--- a/sonha_mdm/views/menu_views.xml
+++ b/sonha_mdm/views/menu_views.xml
@@ -16,6 +16,12 @@
               action="action_mdm_khach_hang"
               sequence="2"/>
 
+    <menuitem id="menu_mdm_khach_hang_import"
+              name="Import Excel khách hàng"
+              parent="menu_sonha_mdm"
+              action="sonha_mdm.action_mdm_khach_hang_import_wizard"
+              sequence="3"/>
+
     <menuitem id="menu_mdm_danh_muc"
               name="Danh mục"
               parent="menu_sonha_mdm"

--- a/sonha_mdm/wizard/__init__.py
+++ b/sonha_mdm/wizard/__init__.py
@@ -1,0 +1,1 @@
+from . import mdm_khach_hang_import_wizard

--- a/sonha_mdm/wizard/mdm_khach_hang_import_wizard.py
+++ b/sonha_mdm/wizard/mdm_khach_hang_import_wizard.py
@@ -1,0 +1,127 @@
+from odoo import fields, models
+from odoo.exceptions import ValidationError
+import base64
+import io
+from openpyxl import load_workbook
+
+
+class MDMKhachHangImportWizard(models.TransientModel):
+    _name = 'mdm.khach.hang.import.wizard'
+    _description = 'Import MDM Khach Hang'
+
+    file = fields.Binary("File Excel", required=True)
+    filename = fields.Char("Tên file")
+
+    def _clean_value(self, value):
+        if value is None:
+            return False
+        if isinstance(value, str):
+            value = value.strip()
+            return value or False
+        return str(value).strip()
+
+    def _get_m2o_by_code(self, model_name, code):
+        if not code:
+            return False
+        record = self.env[model_name].sudo().search([('ma', '=', code)], limit=1)
+        if not record:
+            raise ValidationError(f"Không tìm thấy mã '{code}' trong model {model_name}.")
+        return record.id
+
+    def action_import(self):
+        self.ensure_one()
+        workbook = load_workbook(filename=io.BytesIO(base64.b64decode(self.file)), data_only=True)
+        sheet = workbook.active
+
+        header_map = {
+            'mã tg': 'ma_khach',
+            'ma tg': 'ma_khach',
+            'id': 'ma_dms',
+            'tên ngắn': 'ten_khach',
+            'ten ngan': 'ten_khach',
+            'tên đầy đủ': 'dia_chi_khach',
+            'ten day du': 'dia_chi_khach',
+            'đvt': 'ma_cn',
+            'dvt': 'ma_cn',
+            'chủng loại 1': 'nhom_khach',
+            'chung loai 1': 'nhom_khach',
+            'chủng loại 2': 'ten_salesman',
+            'chung loai 2': 'ten_salesman',
+            'lĩnh vực': 'ma_tinh',
+            'linh vuc': 'ma_tinh',
+            'ngành hàng': 'dat_nuoc',
+            'nganh hang': 'dat_nuoc',
+            'nhãn hàng': 'khu_vuc',
+            'nhan hang': 'khu_vuc',
+            'chất liệu': 'qlv',
+            'chat lieu': 'qlv',
+            'độ bóng': 'mien_lon',
+            'do bong': 'mien_lon',
+            'độ dày': 'mien_nho',
+            'do day': 'mien_nho',
+            'đvt thể tích': 'plan',
+            'dvt the tich': 'plan',
+        }
+
+        many2one_model_map = {
+            'ma_cn': 'mdm.chi.nhanh',
+            'nhom_khach': 'mdm.nhom.khach',
+            'ten_salesman': 'mdm.saleman',
+            'ma_tinh': 'mdm.tinh',
+            'dat_nuoc': 'mdm.quoc.gia',
+            'khu_vuc': 'mdm.khu.vuc',
+            'qlv': 'mdm.quan.ly.vung',
+            'plan': 'mdm.plan',
+            'mien_lon': 'mien.lon',
+            'mien_nho': 'mien.nho',
+        }
+
+        headers = []
+        for col in range(1, sheet.max_column + 1):
+            cell = sheet.cell(row=1, column=col).value
+            headers.append((cell or '').strip().lower() if isinstance(cell, str) else '')
+
+        processed = 0
+        for row_idx in range(2, sheet.max_row + 1):
+            values = {}
+            is_empty = True
+            for col_idx, header in enumerate(headers, start=1):
+                field_name = header_map.get(header)
+                if not field_name:
+                    continue
+                raw_value = self._clean_value(sheet.cell(row=row_idx, column=col_idx).value)
+                if raw_value:
+                    is_empty = False
+                if field_name in many2one_model_map:
+                    values[field_name] = self._get_m2o_by_code(many2one_model_map[field_name], raw_value)
+                else:
+                    values[field_name] = raw_value
+
+            if is_empty:
+                continue
+
+            ma_tg = values.get('ma_khach')
+            if not ma_tg:
+                raise ValidationError(f"Dòng {row_idx} thiếu 'Mã TG'.")
+
+            existed = self.env['mdm.khach.hang'].sudo().search([('ma_khach', '=', ma_tg)], limit=1)
+            if existed:
+                existed.write(values)
+            else:
+                if not values.get('ten_khach'):
+                    values['ten_khach'] = ma_tg
+                if not values.get('so_dien_thoai'):
+                    values['so_dien_thoai'] = '0000000000'
+                self.env['mdm.khach.hang'].sudo().create(values)
+            processed += 1
+
+        return {
+            'type': 'ir.actions.client',
+            'tag': 'display_notification',
+            'params': {
+                'title': 'Import thành công',
+                'message': f'Đã xử lý {processed} dòng dữ liệu.',
+                'type': 'success',
+                'sticky': False,
+            }
+        }

--- a/sonha_mdm/wizard/mdm_khach_hang_import_wizard_views.xml
+++ b/sonha_mdm/wizard/mdm_khach_hang_import_wizard_views.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_mdm_khach_hang_import_wizard_form" model="ir.ui.view">
+        <field name="name">mdm.khach.hang.import.wizard.form</field>
+        <field name="model">mdm.khach.hang.import.wizard</field>
+        <field name="arch" type="xml">
+            <form string="Import khách hàng">
+                <group>
+                    <field name="file" filename="filename"/>
+                    <field name="filename" invisible="1"/>
+                </group>
+                <footer>
+                    <button name="action_import" type="object" string="Import" class="btn-primary"/>
+                    <button string="Hủy" special="cancel" class="btn-secondary"/>
+                </footer>
+            </form>
+        </field>
+    </record>
+</odoo>

--- a/sonha_mdm/wizard/mdm_khach_hang_import_wizard_views.xml
+++ b/sonha_mdm/wizard/mdm_khach_hang_import_wizard_views.xml
@@ -16,4 +16,13 @@
             </form>
         </field>
     </record>
+
+
+    <record id="action_mdm_khach_hang_import_wizard" model="ir.actions.act_window">
+        <field name="name">Import khách hàng</field>
+        <field name="res_model">mdm.khach.hang.import.wizard</field>
+        <field name="view_mode">form</field>
+        <field name="view_id" ref="view_mdm_khach_hang_import_wizard_form"/>
+        <field name="target">new</field>
+    </record>
 </odoo>


### PR DESCRIPTION
### Motivation
- Thêm chức năng cho màn hình MDM khách hàng để import dữ liệu Excel theo mẫu và tự động upsert theo `Mã TG`.
- Khi import phải hỗ trợ đối chiếu các trường many2one bằng `ma` và cập nhật bản ghi nếu `ma_khach` trùng.

### Description
- Thêm wizard mới `mdm.khach.hang.import.wizard` (file `sonha_mdm/wizard/mdm_khach_hang_import_wizard.py`) và view import (`wizard/mdm_khach_hang_import_wizard_views.xml`) để upload file Excel và chạy import.
- Thực hiện mapping header tiếng Việt -> field model trong `header_map`, xử lý many2one bằng cách lookup theo trường `ma` qua `_get_m2o_by_code` và báo lỗi nếu mã không tồn tại.
- Thực hiện cơ chế upsert theo `ma_khach`: nếu tồn tại bản ghi (`ma_khach`) thì `write` cập nhật, nếu chưa có thì `create` với một vài giá trị mặc định (`ten_khach` hoặc `so_dien_thoai` khi thiếu).
- Cập nhật tree view MDM khách hàng để thêm nút `Import Excel`, đăng ký wizard trong `__init__.py` và `__manifest__.py`, và thêm quyền truy cập cho wizard trong `security/ir.model.access.csv`.

### Testing
- Đã chạy biên dịch kiểm tra cú pháp Python với `python -m py_compile sonha_mdm/models/mdm_khach_hang.py sonha_mdm/wizard/mdm_khach_hang_import_wizard.py sonha_mdm/__init__.py sonha_mdm/wizard/__init__.py` và kết quả là thành công.
- Không có test tự động chức năng import (chỉ kiểm tra biên dịch); runtime import cần kiểm tra trên môi trường Odoo với file mẫu.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01311c44648324b744433023c78cae)