### PR TITLE
Add Excel import wizard for MDM hàng hóa with menu and access control

### DIFF
--- a/sonha_mdm/__init__.py
+++ b/sonha_mdm/__init__.py
@@ -1,1 +1,2 @@
 from . import models
+from . import wizard

--- a/sonha_mdm/__manifest__.py
+++ b/sonha_mdm/__manifest__.py
@@ -35,6 +35,7 @@
         'views/mien_lon_views.xml',
         'views/mien_nho_views.xml',
         'data/cron_job.xml',
+        'wizard/mdm_khach_hang_import_wizard_views.xml',
         'views/menu_views.xml',
     ],
     'assets': {

--- a/sonha_mdm/models/mdm_khach_hang.py
+++ b/sonha_mdm/models/mdm_khach_hang.py
@@ -329,6 +329,7 @@ class MDMKhachHang(models.Model):
         if logs:
             self.env['ket.qua.khach.hang'].sudo().create(logs)
 
+
     def action_open_update_popup(self):
         self.ensure_one()
 

--- a/sonha_mdm/security/ir.model.access.csv
+++ b/sonha_mdm/security/ir.model.access.csv
@@ -34,3 +34,4 @@ access_quan_huyen_cu,quan.huyen.cu,model_quan_huyen_cu,,1,1,1,1
 access_tinh_cu,tinh.cu,model_tinh_cu,,1,1,1,1
 access_mdm_plan,mdm.plan,model_mdm_plan,,1,1,1,1
 access_mien_nho,mien.nho,model_mien_nho,,1,1,1,1
+access_mdm_tong_hop_import_wizard,mdm.tong.hop.import.wizard,model_mdm_tong_hop_import_wizard,,1,1,1,1

--- a/sonha_mdm/views/menu_views.xml
+++ b/sonha_mdm/views/menu_views.xml
@@ -9,12 +9,18 @@
               parent="menu_sonha_mdm"
               action="action_mdm_tong_hop"
               sequence="1"/>
+    <menuitem id="menu_mdm_tong_hop_import"
+              name="Import Excel hàng hóa"
+              parent="menu_sonha_mdm"
+              action="sonha_mdm.action_mdm_tong_hop_import_wizard"
+              sequence="2"/>
+
 
     <menuitem id="menu_mdm_khach_hang"
               name="MDM khách hàng"
               parent="menu_sonha_mdm"
               action="action_mdm_khach_hang"
-              sequence="2"/>
+              sequence="3"/>
 
     <menuitem id="menu_mdm_danh_muc"
               name="Danh mục"

--- a/sonha_mdm/wizard/__init__.py
+++ b/sonha_mdm/wizard/__init__.py
@@ -1,0 +1,1 @@
+from . import mdm_khach_hang_import_wizard

--- a/sonha_mdm/wizard/mdm_khach_hang_import_wizard.py
+++ b/sonha_mdm/wizard/mdm_khach_hang_import_wizard.py
@@ -1,0 +1,130 @@
+from odoo import fields, models
+from odoo.exceptions import ValidationError
+import base64
+import io
+from openpyxl import load_workbook
+
+
+class MDMTongHopImportWizard(models.TransientModel):
+    _name = 'mdm.tong.hop.import.wizard'
+    _description = 'Import MDM Hang Hoa'
+
+    file = fields.Binary("File Excel", required=True)
+    filename = fields.Char("Tên file")
+
+    def _clean_value(self, value):
+        if value is None:
+            return False
+        if isinstance(value, str):
+            value = value.strip()
+            return value or False
+        if isinstance(value, float) and value.is_integer():
+            return str(int(value))
+        return str(value).strip()
+
+    def _get_m2o_by_code(self, model_name, code, row_idx, field_label):
+        if not code:
+            return False
+        record = self.env[model_name].sudo().search([('ma', '=', code)], limit=1)
+        if not record:
+            raise ValidationError(f"Dòng {row_idx}: Không tìm thấy mã '{code}' cho cột '{field_label}'.")
+        return record.id
+
+    def action_import(self):
+        self.ensure_one()
+        workbook = load_workbook(filename=io.BytesIO(base64.b64decode(self.file)), data_only=True)
+        sheet = workbook.active
+
+        header_map = {
+            'mã tg': 'ma_tg',
+            'ma tg': 'ma_tg',
+            'id': 'ma',
+            'loại hàng hóa': 'mdm_hh_type_id',
+            'loai hang hoa': 'mdm_hh_type_id',
+            'tên ngắn': 'ten_ngan',
+            'ten ngan': 'ten_ngan',
+            'tên đầy đủ': 'ten',
+            'ten day du': 'ten',
+            'đvt': 'dvt',
+            'dvt': 'dvt',
+            'chủng loại 1': 'chung_loai1',
+            'chung loai 1': 'chung_loai1',
+            'chủng loại 2': 'chung_loai2',
+            'chung loai 2': 'chung_loai2',
+            'lĩnh vực': 'linh_vuc',
+            'linh vuc': 'linh_vuc',
+            'ngành hàng': 'nganh_hang',
+            'nganh hang': 'nganh_hang',
+            'nhãn hàng': 'nhan_hang',
+            'nhan hang': 'nhan_hang',
+            'chất liệu': 'chat_lieu',
+            'chat lieu': 'chat_lieu',
+            'độ bóng': 'do_bong',
+            'do bong': 'do_bong',
+            'độ dày': 'do_day',
+            'do day': 'do_day',
+            'đvt thể tích': 'dung_tich',
+            'dvt the tich': 'dung_tich',
+        }
+
+        many2one_model_map = {
+            'mdm_hh_type_id': ('mdm.hh.type', 'Loại hàng hóa'),
+            'chung_loai1': ('mdm.chung.loai1', 'Chủng loại 1'),
+            'chung_loai2': ('mdm.chung.loai2', 'Chủng loại 2'),
+            'linh_vuc': ('mdm.linh.vuc', 'Lĩnh vực'),
+            'nganh_hang': ('mdm.nganh.hang', 'Ngành hàng'),
+            'nhan_hang': ('mdm.nhan.hang', 'Nhãn hàng'),
+            'chat_lieu': ('mdm.chat.lieu', 'Chất liệu'),
+            'do_bong': ('mdm.do.bong', 'Độ bóng'),
+            'do_day': ('mdm.do.day', 'Độ dày'),
+            'dung_tich': ('mdm.dung.tich', 'ĐVT thể tích'),
+        }
+
+        headers = []
+        for col in range(1, sheet.max_column + 1):
+            cell = sheet.cell(row=1, column=col).value
+            headers.append((cell or '').strip().lower() if isinstance(cell, str) else '')
+
+        processed = 0
+        for row_idx in range(2, sheet.max_row + 1):
+            values = {}
+            is_empty = True
+            for col_idx, header in enumerate(headers, start=1):
+                field_name = header_map.get(header)
+                if not field_name:
+                    continue
+                raw_value = self._clean_value(sheet.cell(row=row_idx, column=col_idx).value)
+                if raw_value:
+                    is_empty = False
+                if field_name in many2one_model_map:
+                    model_name, field_label = many2one_model_map[field_name]
+                    values[field_name] = self._get_m2o_by_code(model_name, raw_value, row_idx, field_label)
+                else:
+                    values[field_name] = raw_value
+
+            if is_empty:
+                continue
+
+            ma_tg = values.get('ma_tg')
+            if not ma_tg:
+                raise ValidationError(f"Dòng {row_idx} thiếu 'Mã TG'.")
+
+            existed = self.env['mdm.tong.hop'].sudo().search([('ma_tg', '=', ma_tg)], limit=1)
+            if existed:
+                existed.write(values)
+            else:
+                if not values.get('ten'):
+                    values['ten'] = ma_tg
+                self.env['mdm.tong.hop'].sudo().create(values)
+            processed += 1
+
+        return {
+            'type': 'ir.actions.client',
+            'tag': 'display_notification',
+            'params': {
+                'title': 'Import thành công',
+                'message': f'Đã xử lý {processed} dòng dữ liệu hàng hóa.',
+                'type': 'success',
+                'sticky': False,
+            }
+        }

--- a/sonha_mdm/wizard/mdm_khach_hang_import_wizard_views.xml
+++ b/sonha_mdm/wizard/mdm_khach_hang_import_wizard_views.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_mdm_tong_hop_import_wizard_form" model="ir.ui.view">
+        <field name="name">mdm.tong.hop.import.wizard.form</field>
+        <field name="model">mdm.tong.hop.import.wizard</field>
+        <field name="arch" type="xml">
+            <form string="Import MDM hàng hóa">
+                <group>
+                    <field name="file" filename="filename"/>
+                    <field name="filename" invisible="1"/>
+                </group>
+                <footer>
+                    <button name="action_import" type="object" string="Import" class="btn-primary"/>
+                    <button string="Hủy" special="cancel" class="btn-secondary"/>
+                </footer>
+            </form>
+        </field>
+    </record>
+
+    <record id="action_mdm_tong_hop_import_wizard" model="ir.actions.act_window">
+        <field name="name">Import Excel MDM hàng hóa</field>
+        <field name="res_model">mdm.tong.hop.import.wizard</field>
+        <field name="view_mode">form</field>
+        <field name="view_id" ref="view_mdm_tong_hop_import_wizard_form"/>
+        <field name="target">new</field>
+    </record>
+</odoo>


### PR DESCRIPTION
### Motivation
- Provide a user-friendly way to bulk import or update `mdm.tong.hop` (MDM hàng hóa) records from Excel files.
- Wire the import flow into the UI and permission model so users can run imports from the MDM menu.

### Description
- Introduce a transient model `mdm.tong.hop.import.wizard` implementing Excel import using `openpyxl`, header mapping, and many2one resolution by `ma` codes, and add validation for missing `Mã TG` and missing reference codes.
- Add wizard view and action in `wizard/mdm_khach_hang_import_wizard_views.xml` and register the view in the module manifest.
- Add a new menu item `menu_mdm_tong_hop_import` pointing to the import wizard and include an ACL `access_mdm_tong_hop_import_wizard` for the wizard model.
- Wire the new wizard package by importing `wizard` in the module `__init__.py` and add the new wizard files under `wizard/`.

### Testing
- No automated tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01311c44648324b744433023c78cae)