### PR TITLE
[sonha_mdm] Add Excel import wizard for MDM goods (upsert by Mã TG)

### DIFF
--- a/sonha_mdm/__manifest__.py
+++ b/sonha_mdm/__manifest__.py
@@ -27,6 +27,7 @@
         'views/mdm_khu_vuc_views.xml',
         'views/mdm_quan_ly_vung_views.xml',
         'views/mdm_tong_hop_views.xml',
+        'views/mdm_tong_hop_import_wizard_views.xml',
         'views/mdm_khach_hang_views.xml',
         'views/phuong_xa_cu_views.xml',
         'views/quan_huyen_cu_views.xml',

--- a/sonha_mdm/models/__init__.py
+++ b/sonha_mdm/models/__init__.py
@@ -27,3 +27,4 @@ from . import plan
 from . import tinh_cu
 from . import mien_lon
 from . import mien_nho
+from . import mdm_tong_hop_import_wizard

--- a/sonha_mdm/models/mdm_tong_hop.py
+++ b/sonha_mdm/models/mdm_tong_hop.py
@@ -184,6 +184,16 @@ class MDMTongHop(models.Model):
     #         if record.nhan_hang and record.key_nhan_hang and record.nhan_hang.key_map != record.key_nhan_hang:
     #             record.nhan_hang = False
 
+
+    def action_open_import_wizard(self):
+        return {
+            'type': 'ir.actions.act_window',
+            'name': 'Import MDM Hàng hóa',
+            'res_model': 'mdm.tong.hop.import.wizard',
+            'view_mode': 'form',
+            'target': 'new',
+        }
+
     def _normalize_name(self, text):
         text = (text or "").lower()
         text = unicodedata.normalize('NFD', text)

--- a/sonha_mdm/models/mdm_tong_hop_import_wizard.py
+++ b/sonha_mdm/models/mdm_tong_hop_import_wizard.py
@@ -1,0 +1,100 @@
+import base64
+from io import BytesIO
+
+from odoo import _, fields, models
+from odoo.exceptions import ValidationError
+
+try:
+    from openpyxl import load_workbook
+except ImportError:
+    load_workbook = None
+
+
+class MDMTongHopImportWizard(models.TransientModel):
+    _name = 'mdm.tong.hop.import.wizard'
+    _description = 'Import MDM Hàng hóa từ Excel'
+
+    file_data = fields.Binary(string='File Excel', required=True)
+    file_name = fields.Char(string='Tên file')
+
+    def _clean_value(self, value):
+        if value is None:
+            return False
+        if isinstance(value, str):
+            value = value.strip()
+            return value or False
+        return str(value).strip() or False
+
+    def _find_by_code(self, model_name, code):
+        code = self._clean_value(code)
+        if not code:
+            return False
+        return self.env[model_name].search([('ma', '=', code)], limit=1)
+
+    def action_import(self):
+        self.ensure_one()
+
+        if load_workbook is None:
+            raise ValidationError(_('Thiếu thư viện openpyxl để đọc file Excel.'))
+
+        if not self.file_data:
+            raise ValidationError(_('Vui lòng chọn file Excel để import.'))
+
+        workbook = load_workbook(filename=BytesIO(base64.b64decode(self.file_data)), data_only=True)
+        sheet = workbook.active
+
+        model = self.env['mdm.tong.hop']
+
+        imported = 0
+        updated = 0
+        errors = []
+
+        for row_index, row in enumerate(sheet.iter_rows(min_row=2, values_only=True), start=2):
+            ma_tg = self._clean_value(row[0] if len(row) > 0 else False)
+            if not ma_tg:
+                continue
+
+            vals = {
+                'ma_tg': ma_tg,
+                'ma': self._clean_value(row[1] if len(row) > 1 else False),
+                'mdm_hh_type_id': self._find_by_code('mdm.hh.type', row[2] if len(row) > 2 else False).id,
+                'ten_ngan': self._clean_value(row[3] if len(row) > 3 else False),
+                'ten': self._clean_value(row[4] if len(row) > 4 else False),
+                'dvt': self._clean_value(row[5] if len(row) > 5 else False),
+                'chung_loai1': self._find_by_code('mdm.chung.loai1', row[6] if len(row) > 6 else False).id,
+                'chung_loai2': self._find_by_code('mdm.chung.loai2', row[7] if len(row) > 7 else False).id,
+                'linh_vuc': self._find_by_code('mdm.linh.vuc', row[8] if len(row) > 8 else False).id,
+                'nganh_hang': self._find_by_code('mdm.nganh.hang', row[9] if len(row) > 9 else False).id,
+                'nhan_hang': self._find_by_code('mdm.nhan.hang', row[10] if len(row) > 10 else False).id,
+                'chat_lieu': self._find_by_code('mdm.chat.lieu', row[11] if len(row) > 11 else False).id,
+                'do_bong': self._find_by_code('mdm.do.bong', row[12] if len(row) > 12 else False).id,
+                'do_day': self._find_by_code('mdm.do.day', row[13] if len(row) > 13 else False).id,
+                'dung_tich': self._find_by_code('mdm.dung.tich', row[14] if len(row) > 14 else False).id,
+            }
+
+            try:
+                existing = model.search([('ma_tg', '=', ma_tg)], limit=1)
+                if existing:
+                    existing.write(vals)
+                    updated += 1
+                else:
+                    model.create(vals)
+                    imported += 1
+            except Exception as exc:
+                errors.append(_('Dòng %(row)s (Mã TG: %(ma_tg)s): %(error)s', row=row_index, ma_tg=ma_tg, error=str(exc)))
+
+        message = _('Import hoàn tất. Tạo mới: %(new)s, Cập nhật: %(updated)s', new=imported, updated=updated)
+        if errors:
+            message = message + '\n' + '\n'.join(errors[:20])
+            raise ValidationError(message)
+
+        return {
+            'type': 'ir.actions.client',
+            'tag': 'display_notification',
+            'params': {
+                'title': _('Thành công'),
+                'message': message,
+                'type': 'success',
+                'sticky': False,
+            }
+        }

--- a/sonha_mdm/security/ir.model.access.csv
+++ b/sonha_mdm/security/ir.model.access.csv
@@ -34,3 +34,5 @@ access_quan_huyen_cu,quan.huyen.cu,model_quan_huyen_cu,,1,1,1,1
 access_tinh_cu,tinh.cu,model_tinh_cu,,1,1,1,1
 access_mdm_plan,mdm.plan,model_mdm_plan,,1,1,1,1
 access_mien_nho,mien.nho,model_mien_nho,,1,1,1,1
+
+access_mdm_tong_hop_import_wizard,mdm.tong.hop.import.wizard,model_mdm_tong_hop_import_wizard,,1,1,1,1

--- a/sonha_mdm/views/mdm_tong_hop_import_wizard_views.xml
+++ b/sonha_mdm/views/mdm_tong_hop_import_wizard_views.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="view_mdm_tong_hop_import_wizard_form" model="ir.ui.view">
+        <field name="name">mdm.tong.hop.import.wizard.form</field>
+        <field name="model">mdm.tong.hop.import.wizard</field>
+        <field name="arch" type="xml">
+            <form string="Import MDM Hàng hóa">
+                <group>
+                    <field name="file_name" invisible="1"/>
+                    <field name="file_data" filename="file_name" required="1"/>
+                </group>
+                <footer>
+                    <button name="action_import" type="object" string="Import" class="btn-primary"/>
+                    <button string="Hủy" special="cancel" class="btn-secondary"/>
+                </footer>
+            </form>
+        </field>
+    </record>
+</odoo>

--- a/sonha_mdm/views/mdm_tong_hop_views.xml
+++ b/sonha_mdm/views/mdm_tong_hop_views.xml
@@ -113,6 +113,9 @@
         <field name="model">mdm.tong.hop</field>
         <field name="arch" type="xml">
             <tree string="MDM Hàng hóa" default_order="create_date desc">
+                <header>
+                    <button name="action_open_import_wizard" type="object" string="Import Excel" class="btn-primary"/>
+                </header>
                 <field name="ma_tg" optional="show"/>
                 <field name="mdm_hh_type_id" optional="show"/>
                 <field name="mdm_hh_type" optional="show"/>


### PR DESCRIPTION
### Motivation
- Cần một màn hình riêng để import file Excel theo template cho dữ liệu MDM hàng hóa để dễ kiểm soát và thao tác batch. 
- Khi import, các trường `Many2one` phải đối chiếu bằng `ma` (mã) thay vì id, và nếu trùng `ma_tg` thì cập nhật dữ liệu hiện có (upsert).

### Description
- Thêm transient wizard `mdm.tong.hop.import.wizard` với fields `file_data`/`file_name` và method `action_import` để đọc file Excel bằng `openpyxl` và xử lý từng dòng. 
- Ánh xạ cột theo template vào `mdm.tong.hop` và thực hiện lookup `Many2one` bằng hàm `_find_by_code` trên trường `ma` cho các model liên quan (ví dụ `mdm.hh.type`, `mdm.chung.loai1`, `mdm.chung.loai2`, `mdm.linh.vuc`, `mdm.nganh.hang`, `mdm.nhan.hang`, `mdm.chat.lieu`, `mdm.do.bong`, `mdm.do.day`, `mdm.dung.tich`).
- Triển khai logic upsert theo `ma_tg`: nếu tồn tại record có cùng `ma_tg` thì gọi `write(vals)` để cập nhật, nếu không thì `create(vals)` để tạo mới.
- Thêm nút `Import Excel` trên tree view của `mdm.tong.hop`, đăng ký view wizard trong `__manifest__.py`, import wizard vào `models/__init__.py` và thêm quyền truy cập cho model transient trong `security/ir.model.access.csv`.

### Testing
- Biên dịch Python check: `python -m py_compile sonha_mdm/models/mdm_tong_hop.py sonha_mdm/models/mdm_tong_hop_import_wizard.py` đã chạy thành công (no syntax errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a014d0c6ba4832489f87c29e5b9bb92)