### PR TITLE
Fix create-record crash from unknown approver user

### DIFF
--- a/sonha_mdm/models/mdm_khach_hang.py
+++ b/sonha_mdm/models/mdm_khach_hang.py
@@ -62,7 +62,7 @@ class MDMKhachHang(models.Model):
             )
 
             rec.can_approve = any(
-                step.ten_nguoi_duyet.id == user.id and not step.da_duyet
+                step.ten_nguoi_duyet and step.ten_nguoi_duyet == user and not step.da_duyet
                 for step in steps
             )
 
@@ -77,7 +77,7 @@ class MDMKhachHang(models.Model):
 
             # tìm dòng của user hiện tại
             my_step = steps.filtered(
-                lambda x: x.ten_nguoi_duyet.id == user.id
+                lambda x: x.ten_nguoi_duyet and x.ten_nguoi_duyet == user
             )[:1]
 
             if not my_step:
@@ -111,7 +111,7 @@ class MDMKhachHang(models.Model):
                         'sequence': step.sequence,
                         'phuong_thuc': step.phuong_thuc,
                         'vai_tro': step.vai_tro.id,
-                        'ten_nguoi_duyet': 2,
+                        'ten_nguoi_duyet': self.env.user.id,
                     }))
                 else:
                     for user in step.ten_nguoi_duyet:

--- a/sonha_mdm/models/mdm_tong_hop.py
+++ b/sonha_mdm/models/mdm_tong_hop.py
@@ -73,7 +73,7 @@ class MDMTongHop(models.Model):
             )
 
             rec.can_approve = any(
-                step.ten_nguoi_duyet.id == user.id and not step.da_duyet
+                step.ten_nguoi_duyet and step.ten_nguoi_duyet == user and not step.da_duyet
                 for step in steps
             )
 
@@ -88,7 +88,7 @@ class MDMTongHop(models.Model):
 
             # tìm dòng của user hiện tại
             my_step = steps.filtered(
-                lambda x: x.ten_nguoi_duyet.id == user.id
+                lambda x: x.ten_nguoi_duyet and x.ten_nguoi_duyet == user
             )[:1]
 
             if not my_step:
@@ -122,7 +122,7 @@ class MDMTongHop(models.Model):
                         'sequence': step.sequence,
                         'phuong_thuc': step.phuong_thuc,
                         'vai_tro': step.vai_tro.id,
-                        'ten_nguoi_duyet': 2,
+                        'ten_nguoi_duyet': self.env.user.id,
                     }))
                 else:
                     for user in step.ten_nguoi_duyet:


### PR DESCRIPTION
### Motivation
- Prevent `AttributeError: '_unknown' object has no attribute 'id'` when creating records where approval-step `ten_nguoi_duyet` may be unset or unresolved. 
- Avoid inserting an invalid Many2one value (hardcoded `2`) when generating approval-step lines on `luong_duyet` onchange.

### Description
- Changed approval checks to guard against empty/unresolved approver records by checking `ten_nguoi_duyet` and comparing the record object to `self.env.user` instead of dereferencing `.id` in `mdm.khach.hang` and `mdm.tong.hop`.
- Replaced the hardcoded `'ten_nguoi_duyet': 2` with `'ten_nguoi_duyet': self.env.user.id` when building `buoc_duyet` lines in the `@api.onchange('luong_duyet')` handlers in both `sonha_mdm/models/mdm_khach_hang.py` and `sonha_mdm/models/mdm_tong_hop.py`.
- Applied the same guarded lambda filters and logic in both models so creation and approval flows behave consistently.

### Testing
- Ran `python -m py_compile sonha_mdm/models/mdm_khach_hang.py sonha_mdm/models/mdm_tong_hop.py` and the files compiled successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03e0228f948324aa30fea6db3f971c)