### PR TITLE
[sonha_mdm] Move Excel import to dedicated menu popup

### DIFF
--- a/sonha_mdm/views/mdm_tong_hop_views.xml
+++ b/sonha_mdm/views/mdm_tong_hop_views.xml
@@ -146,13 +146,11 @@
                 (0, 0, {'view_mode': 'tree', 'view_id': ref('view_mdm_tong_hop_tree')}),
                 (0, 0, {'view_mode': 'form', 'view_id': ref('view_mdm_tong_hop_form')})]"/>
         </record>
-    <record id="action_mdm_tong_hop_import_excel" model="ir.actions.server">
+    <record id="action_mdm_tong_hop_import_excel" model="ir.actions.act_window">
         <field name="name">Import Excel</field>
-        <field name="model_id" ref="model_mdm_tong_hop"/>
-        <field name="binding_model_id" ref="model_mdm_tong_hop"/>
-        <field name="binding_view_types">list</field>
-        <field name="state">code</field>
-        <field name="code">action = model.action_open_import_wizard()</field>
+        <field name="res_model">mdm.tong.hop.import.wizard</field>
+        <field name="view_mode">form</field>
+        <field name="target">new</field>
     </record>
 
 </odoo>

--- a/sonha_mdm/views/menu_views.xml
+++ b/sonha_mdm/views/menu_views.xml
@@ -15,6 +15,11 @@
               parent="menu_sonha_mdm"
               action="action_mdm_khach_hang"
               sequence="2"/>
+    <menuitem id="menu_mdm_tong_hop_import_excel"
+              name="Import MDM Hàng hóa"
+              parent="menu_sonha_mdm"
+              action="action_mdm_tong_hop_import_excel"
+              sequence="3"/>
 
     <menuitem id="menu_mdm_danh_muc"
               name="Danh mục"


### PR DESCRIPTION
### Motivation
- Provide a dedicated entry point for the Excel import flow so the import is launched from a top-level menu and opens the existing wizard as a popup rather than being bound to a list/server action.

### Description
- Converted `action_mdm_tong_hop_import_excel` from an `ir.actions.server` to an `ir.actions.act_window` that opens `mdm.tong.hop.import.wizard` in form mode with `target="new"`.
- Added a new menu item `menu_mdm_tong_hop_import_excel` under `menu_sonha_mdm` that points to the new window action.
- Files changed: `sonha_mdm/views/mdm_tong_hop_views.xml` and `sonha_mdm/views/menu_views.xml`.

### Testing
- No automated tests were executed for this change; the XML changes were validated by inspecting the resulting diffs and the updated view/menu definitions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0681bea5008324b82afcdce1ef8523)