### PR TITLE
[sonha_mdm] Add bom_sale master data model and Danh mục menu

### DIFF
--- a/sonha_mdm/__manifest__.py
+++ b/sonha_mdm/__manifest__.py
@@ -35,6 +35,7 @@
         'views/plan_views.xml',
         'views/mien_lon_views.xml',
         'views/mien_nho_views.xml',
+        'views/bom_sale_views.xml',
         'data/cron_job.xml',
         'views/menu_views.xml',
     ],

--- a/sonha_mdm/models/__init__.py
+++ b/sonha_mdm/models/__init__.py
@@ -28,3 +28,5 @@ from . import tinh_cu
 from . import mien_lon
 from . import mien_nho
 from . import mdm_tong_hop_import_wizard
+
+from . import bom_sale

--- a/sonha_mdm/models/bom_sale.py
+++ b/sonha_mdm/models/bom_sale.py
@@ -1,0 +1,9 @@
+from odoo import fields, models
+
+
+class BomSale(models.Model):
+    _name = 'bom.sale'
+    _rec_name = 'ten'
+
+    ma = fields.Char("Mã", store=True)
+    ten = fields.Char("Tên", store=True)

--- a/sonha_mdm/security/ir.model.access.csv
+++ b/sonha_mdm/security/ir.model.access.csv
@@ -36,3 +36,4 @@ access_mdm_plan,mdm.plan,model_mdm_plan,,1,1,1,1
 access_mien_nho,mien.nho,model_mien_nho,,1,1,1,1
 
 access_mdm_tong_hop_import_wizard,mdm.tong.hop.import.wizard,model_mdm_tong_hop_import_wizard,,1,1,1,1
+access_bom_sale,bom.sale,model_bom_sale,,1,1,1,1

--- a/sonha_mdm/views/bom_sale_views.xml
+++ b/sonha_mdm/views/bom_sale_views.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+
+    <record id="view_bom_sale_tree" model="ir.ui.view">
+        <field name="name">BOM Sale</field>
+        <field name="model">bom.sale</field>
+        <field name="arch" type="xml">
+            <tree string="BOM Sale" editable="bottom">
+                <field name="ma"/>
+                <field name="ten"/>
+            </tree>
+        </field>
+    </record>
+
+    <record id="action_bom_sale" model="ir.actions.act_window">
+        <field name="name">BOM Sale</field>
+        <field name="res_model">bom.sale</field>
+        <field name="view_mode">tree</field>
+    </record>
+</odoo>

--- a/sonha_mdm/views/menu_views.xml
+++ b/sonha_mdm/views/menu_views.xml
@@ -163,4 +163,11 @@
               parent="menu_mdm_danh_muc"
               action="sonha_mdm.action_mien_nho"
               sequence="23"/>
+
+    <menuitem id="menu_bom_sale"
+              name="BOM Sale"
+              parent="menu_mdm_danh_muc"
+              action="sonha_mdm.action_bom_sale"
+              sequence="24"/>
+
 </odoo>


### PR DESCRIPTION
### Motivation
- Thêm một dữ liệu danh mục đơn giản để quản lý BOM Sale (mã và tên) trong module `sonha_mdm` và hiển thị nó trong nhóm menu `MDM > Danh mục`.

### Description
- Thêm file `sonha_mdm/models/bom_sale.py` với model `bom.sale` và hai field là `ma` và `ten`, và `_rec_name = 'ten'`.
- Thêm tree view và window action trong `sonha_mdm/views/bom_sale_views.xml` để quản lý bản ghi `bom.sale`.
- Đăng ký view vào `sonha_mdm/__manifest__.py` và import model trong `sonha_mdm/models/__init__.py`.
- Thêm quyền truy cập cho model trong `sonha_mdm/security/ir.model.access.csv` và thêm menu `BOM Sale` vào `sonha_mdm/views/menu_views.xml` dưới `menu_mdm_danh_muc`.

### Testing
- Chạy `python -m py_compile sonha_mdm/models/bom_sale.py` và biên dịch file Python thành công.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06853f3bdc832493cb9cd5485e88ea)