### PR TITLE
Fix sonha_mdm import action XML ID conflict

### DIFF
--- a/sonha_mdm/views/mdm_tong_hop_views.xml
+++ b/sonha_mdm/views/mdm_tong_hop_views.xml
@@ -148,7 +148,7 @@
                 (0, 0, {'view_mode': 'tree', 'view_id': ref('view_mdm_tong_hop_tree')}),
                 (0, 0, {'view_mode': 'form', 'view_id': ref('view_mdm_tong_hop_form')})]"/>
         </record>
-    <record id="action_mdm_tong_hop_import_excel" model="ir.actions.act_window">
+    <record id="action_mdm_tong_hop_import_excel_wizard" model="ir.actions.act_window">
         <field name="name">Import Excel</field>
         <field name="res_model">mdm.tong.hop.import.wizard</field>
         <field name="view_mode">form</field>

--- a/sonha_mdm/views/menu_views.xml
+++ b/sonha_mdm/views/menu_views.xml
@@ -18,7 +18,7 @@
     <menuitem id="menu_mdm_tong_hop_import_excel"
               name="Import MDM Hàng hóa"
               parent="menu_sonha_mdm"
-              action="action_mdm_tong_hop_import_excel"
+              action="action_mdm_tong_hop_import_excel_wizard"
               sequence="3"/>
 
     <menuitem id="menu_mdm_danh_muc"


### PR DESCRIPTION
### Motivation
- Resolve an Odoo upgrade `ParseError` caused by reusing the external ID `sonha_mdm.action_mdm_tong_hop_import_excel` for a different model (`ir.actions.server` vs `ir.actions.act_window`).
- Avoid cross-model external-ID collisions by creating a new XML ID for the import wizard action and updating references.

### Description
- Renamed the action record ID in `sonha_mdm/views/mdm_tong_hop_views.xml` from `action_mdm_tong_hop_import_excel` to `action_mdm_tong_hop_import_excel_wizard` and left it as `ir.actions.act_window` with `res_model` `mdm.tong.hop.import.wizard`.
- Updated the menu item in `sonha_mdm/views/menu_views.xml` to reference the new action ID `action_mdm_tong_hop_import_excel_wizard`.
- Changes were committed with message `Fix MDM import action XML ID model conflict`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0687ef820c83249e295dbf0407cce4)