### PR TITLE
Add dung_tich_plus field and import wizard auto-create lookup records

### DIFF
--- a/sonha_mdm/models/mdm_tong_hop.py
+++ b/sonha_mdm/models/mdm_tong_hop.py
@@ -47,6 +47,7 @@ class MDMTongHop(models.Model):
     chat_lieu = fields.Many2one('mdm.chat.lieu', string="Chất liệu")
     do_bong = fields.Many2one('mdm.do.bong', string="Độ bóng")
     do_day = fields.Many2one('mdm.do.day', string="Độ dày")
+    dung_tich_plus = fields.Char(string="Dung tích plus")
     dung_tich = fields.Many2one('mdm.dung.tich', string="Dung tích")
     dvt_dung_tich = fields.Char(string="ĐVT Dung tích")
     bom_sale = fields.Many2one('bom.sale', string="Loại trong BOM sales")
@@ -501,4 +502,3 @@ class MDMTongHop(models.Model):
             self.create_write_action_data(r)
             self.call_api_update(r)
         return res
-

--- a/sonha_mdm/models/mdm_tong_hop_import_wizard.py
+++ b/sonha_mdm/models/mdm_tong_hop_import_wizard.py
@@ -31,6 +31,20 @@ class MDMTongHopImportWizard(models.TransientModel):
             return False
         return self.env[model_name].search([('ma', '=', code)], limit=1)
 
+    def _find_or_create_by_code(self, model_name, code):
+        code = self._clean_value(code)
+        if not code:
+            return False
+
+        record = self._find_by_code(model_name, code)
+        if record:
+            return record
+
+        return self.env[model_name].create({
+            'ma': code,
+            'ten': code,
+        })
+
     def action_import(self):
         self.ensure_one()
 
@@ -56,20 +70,21 @@ class MDMTongHopImportWizard(models.TransientModel):
 
             vals = {
                 'ma_tg': ma_tg,
-                'ma': self._clean_value(row[1] if len(row) > 1 else False),
-                'mdm_hh_type_id': self._find_by_code('mdm.hh.type', row[2] if len(row) > 2 else False).id,
-                'ten_ngan': self._clean_value(row[3] if len(row) > 3 else False),
-                'ten': self._clean_value(row[4] if len(row) > 4 else False),
-                'dvt': self._clean_value(row[5] if len(row) > 5 else False),
-                'chung_loai1': self._find_by_code('mdm.chung.loai1', row[6] if len(row) > 6 else False).id,
-                'chung_loai2': self._find_by_code('mdm.chung.loai2', row[7] if len(row) > 7 else False).id,
-                'linh_vuc': self._find_by_code('mdm.linh.vuc', row[8] if len(row) > 8 else False).id,
-                'nganh_hang': self._find_by_code('mdm.nganh.hang', row[9] if len(row) > 9 else False).id,
-                'nhan_hang': self._find_by_code('mdm.nhan.hang', row[10] if len(row) > 10 else False).id,
-                'chat_lieu': self._find_by_code('mdm.chat.lieu', row[11] if len(row) > 11 else False).id,
-                'do_bong': self._find_by_code('mdm.do.bong', row[12] if len(row) > 12 else False).id,
-                'do_day': self._find_by_code('mdm.do.day', row[13] if len(row) > 13 else False).id,
-                'dung_tich': self._find_by_code('mdm.dung.tich', row[14] if len(row) > 14 else False).id,
+                'mdm_hh_type_id': self._find_or_create_by_code('mdm.hh.type', row[1] if len(row) > 1 else False).id,
+                'ten_ngan': self._clean_value(row[2] if len(row) > 2 else False),
+                'ten': self._clean_value(row[3] if len(row) > 3 else False),
+                'dvt': self._clean_value(row[4] if len(row) > 4 else False),
+                'chung_loai1': self._find_or_create_by_code('mdm.chung.loai1', row[5] if len(row) > 5 else False).id,
+                'chung_loai2': self._find_or_create_by_code('mdm.chung.loai2', row[6] if len(row) > 6 else False).id,
+                'linh_vuc': self._find_or_create_by_code('mdm.linh.vuc', row[7] if len(row) > 7 else False).id,
+                'nganh_hang': self._find_or_create_by_code('mdm.nganh.hang', row[8] if len(row) > 8 else False).id,
+                'nhan_hang': self._find_or_create_by_code('mdm.nhan.hang', row[9] if len(row) > 9 else False).id,
+                'chat_lieu': self._find_or_create_by_code('mdm.chat.lieu', row[10] if len(row) > 10 else False).id,
+                'do_bong': self._find_or_create_by_code('mdm.do.bong', row[11] if len(row) > 11 else False).id,
+                'do_day': self._find_or_create_by_code('mdm.do.day', row[12] if len(row) > 12 else False).id,
+                'dung_tich_plus': self._clean_value(row[13] if len(row) > 13 else False),
+                'dvt_dung_tich': self._clean_value(row[14] if len(row) > 14 else False),
+                'bom_sale': self._find_or_create_by_code('bom.sale', row[15] if len(row) > 15 else False).id,
             }
 
             try:

--- a/sonha_mdm/views/mdm_tong_hop_views.xml
+++ b/sonha_mdm/views/mdm_tong_hop_views.xml
@@ -127,6 +127,7 @@
                 <field name="chat_lieu" optional="show"/>
                 <field name="do_bong" optional="show"/>
                 <field name="do_day" optional="show"/>
+                <field name="dung_tich_plus" optional="show"/>
                 <field name="dung_tich" optional="show"/>
                 <field name="dvt_dung_tich" optional="show"/>
                 <field name="bom_sale" optional="show"/>


### PR DESCRIPTION
### Motivation
- Make the product import more resilient by auto-creating missing lookup records during Excel import. 
- Capture an extra free-text capacity field `dung_tich_plus` on the MDM product model and show it in the tree view. 
- Simplify mapping from Excel columns to model fields and avoid import failures when referenced lookup codes do not exist.

### Description
- Added a new Char field `dung_tich_plus` to `mdm.tong.hop` and exposed it in the tree view as `<field name="dung_tich_plus"/>`.
- Implemented `_find_or_create_by_code` in the import wizard to return existing records or create new lookup records with `ma`/`ten` when missing.
- Updated `action_import` column mappings to use `_find_or_create_by_code` for many lookup fields and adjusted column indices to include `dung_tich_plus`, `dvt_dung_tich`, and `bom_sale` handling.
- Minor cleanup: removed an extra trailing whitespace line in `mdm_tong_hop.py` (no behavioral change).

### Testing
- No automated tests were added for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a068c775bb8832487fb704729df330d)