### PR TITLE
Fix crash in MDM hàng hóa import when category code is empty

### DIFF
--- a/sonha_mdm/models/mdm_tong_hop_import_wizard.py
+++ b/sonha_mdm/models/mdm_tong_hop_import_wizard.py
@@ -28,13 +28,13 @@ class MDMTongHopImportWizard(models.TransientModel):
     def _find_by_code(self, model_name, code):
         code = self._clean_value(code)
         if not code:
-            return False
+            return self.env[model_name].browse()
         return self.env[model_name].search([('ma', '=', code)], limit=1)
 
     def _find_or_create_by_code(self, model_name, code):
         code = self._clean_value(code)
         if not code:
-            return False
+            return self.env[model_name].browse()
 
         record = self._find_by_code(model_name, code)
         if record:


### PR DESCRIPTION
### Motivation
- The import wizard raised `AttributeError: 'bool' object has no attribute 'id'` when optional lookup Excel cells were blank because `_find_by_code` and `_find_or_create_by_code` returned `False` while callers always accessed `.id`.

### Description
- Change `_find_by_code` and `_find_or_create_by_code` to return an empty recordset with `self.env[model_name].browse()` for empty input so callers can safely use `.id` and optional many2one fields remain empty.

### Testing
- No automated tests were executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0693664374832493337d7814327d13)