### PR TITLE
Add Excel import wizard for MDM customers (mdm.khach.hang.import.wizard)

### DIFF
--- a/sonha_mdm/__manifest__.py
+++ b/sonha_mdm/__manifest__.py
@@ -28,6 +28,7 @@
         'views/mdm_quan_ly_vung_views.xml',
         'views/mdm_tong_hop_views.xml',
         'views/mdm_tong_hop_import_wizard_views.xml',
+        'views/mdm_khach_hang_import_wizard_views.xml',
         'views/mdm_khach_hang_views.xml',
         'views/phuong_xa_cu_views.xml',
         'views/quan_huyen_cu_views.xml',

--- a/sonha_mdm/models/__init__.py
+++ b/sonha_mdm/models/__init__.py
@@ -28,5 +28,6 @@ from . import tinh_cu
 from . import mien_lon
 from . import mien_nho
 from . import mdm_tong_hop_import_wizard
+from . import mdm_khach_hang_import_wizard
 
 from . import bom_sale

--- a/sonha_mdm/models/mdm_khach_hang_import_wizard.py
+++ b/sonha_mdm/models/mdm_khach_hang_import_wizard.py
@@ -1,0 +1,120 @@
+import base64
+from io import BytesIO
+
+from odoo import _, fields, models
+from odoo.exceptions import ValidationError
+
+try:
+    from openpyxl import load_workbook
+except ImportError:
+    load_workbook = None
+
+
+class MDMKhachHangImportWizard(models.TransientModel):
+    _name = 'mdm.khach.hang.import.wizard'
+    _description = 'Import MDM Khách hàng từ Excel'
+
+    file_data = fields.Binary(string='File Excel', required=True)
+    file_name = fields.Char(string='Tên file')
+
+    def _clean_value(self, value):
+        if value is None:
+            return False
+        if isinstance(value, str):
+            value = value.strip()
+            return value or False
+        return str(value).strip() or False
+
+    def _find_or_create_by_name(self, model_name, value):
+        name = self._clean_value(value)
+        if not name:
+            return self.env[model_name].browse()
+
+        record = self.env[model_name].search([('ten', '=', name)], limit=1)
+        if record:
+            return record
+
+        return self.env[model_name].create({'ten': name, 'ma': name})
+
+    def _find_or_create_salesman(self, code):
+        code = self._clean_value(code)
+        if not code:
+            return self.env['mdm.saleman'].browse()
+
+        record = self.env['mdm.saleman'].search([('ma', '=', code)], limit=1)
+        if record:
+            return record
+
+        return self.env['mdm.saleman'].create({'ma': code, 'ten': code})
+
+    def action_import(self):
+        self.ensure_one()
+
+        if load_workbook is None:
+            raise ValidationError(_('Thiếu thư viện openpyxl để đọc file Excel.'))
+
+        if not self.file_data:
+            raise ValidationError(_('Vui lòng chọn file Excel để import.'))
+
+        workbook = load_workbook(filename=BytesIO(base64.b64decode(self.file_data)), data_only=True)
+        sheet = workbook.active
+        model = self.env['mdm.khach.hang']
+
+        imported = 0
+        updated = 0
+        errors = []
+
+        for row_index, row in enumerate(sheet.iter_rows(min_row=2, values_only=True), start=2):
+            ma_khach = self._clean_value(row[0] if len(row) > 0 else False)
+            ten_khach = self._clean_value(row[1] if len(row) > 1 else False)
+            if not ma_khach and not ten_khach:
+                continue
+
+            try:
+                vals = {
+                    'ma_khach': ma_khach,
+                    'ten_khach': ten_khach,
+                    'dia_chi_khach': self._clean_value(row[2] if len(row) > 2 else False),
+                    'phuong_xa_cu': self._find_or_create_by_name('phuong.xa.cu', row[3] if len(row) > 3 else False).id,
+                    'quan_huyen_cu': self._find_or_create_by_name('quan.huyen.cu', row[4] if len(row) > 4 else False).id,
+                    'tinh_cu': self._find_or_create_by_name('tinh.cu', row[5] if len(row) > 5 else False).id,
+                    'dat_nuoc': self._find_or_create_by_name('mdm.quoc.gia', row[6] if len(row) > 6 else False).id,
+                    'so_dien_thoai': self._clean_value(row[7] if len(row) > 7 else False),
+                    'mst': self._clean_value(row[8] if len(row) > 8 else False),
+                    'plan': self._find_or_create_by_name('mdm.plan', row[9] if len(row) > 9 else False).id,
+                    'ma_cn': self._find_or_create_by_name('mdm.chi.nhanh', row[10] if len(row) > 10 else False).id,
+                    'nhom_khach': self._find_or_create_by_name('mdm.nhom.khach', row[11] if len(row) > 11 else False).id,
+                    'dvcs': self.env.company.id,
+                    'ten_salesman': self._find_or_create_salesman(row[13] if len(row) > 13 else False).id,
+                    'vung': self._clean_value(row[14] if len(row) > 14 else False),
+                    'qlv': self._find_or_create_by_name('mdm.quan.ly.vung', row[15] if len(row) > 15 else False).id,
+                    'khu_vuc': self._find_or_create_by_name('mdm.khu.vuc', row[16] if len(row) > 16 else False).id,
+                    'mien_lon': self._find_or_create_by_name('mien.lon', row[17] if len(row) > 17 else False).id,
+                    'mien_nho': self._find_or_create_by_name('mien.nho', row[18] if len(row) > 18 else False).id,
+                }
+
+                existing = model.search([('ma_khach', '=', ma_khach)], limit=1) if ma_khach else model.browse()
+                if existing:
+                    existing.write(vals)
+                    updated += 1
+                else:
+                    model.create(vals)
+                    imported += 1
+            except Exception as exc:
+                errors.append(_('Dòng %(row)s: %(error)s', row=row_index, error=str(exc)))
+
+        message = _('Import hoàn tất. Tạo mới: %(new)s, Cập nhật: %(updated)s', new=imported, updated=updated)
+        if errors:
+            message = message + '\n' + '\n'.join(errors[:20])
+            raise ValidationError(message)
+
+        return {
+            'type': 'ir.actions.client',
+            'tag': 'display_notification',
+            'params': {
+                'title': _('Thành công'),
+                'message': message,
+                'type': 'success',
+                'sticky': False,
+            }
+        }

--- a/sonha_mdm/views/mdm_khach_hang_import_wizard_views.xml
+++ b/sonha_mdm/views/mdm_khach_hang_import_wizard_views.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="view_mdm_khach_hang_import_wizard_form" model="ir.ui.view">
+        <field name="name">mdm.khach.hang.import.wizard.form</field>
+        <field name="model">mdm.khach.hang.import.wizard</field>
+        <field name="arch" type="xml">
+            <form string="Import MDM Khách hàng">
+                <group>
+                    <field name="file_name" invisible="1"/>
+                    <field name="file_data" filename="file_name" required="1"/>
+                </group>
+                <footer>
+                    <button name="action_import" type="object" string="Import" class="btn-primary"/>
+                    <button string="Hủy" special="cancel" class="btn-secondary"/>
+                </footer>
+            </form>
+        </field>
+    </record>
+
+    <record id="action_mdm_khach_hang_import_excel_wizard" model="ir.actions.act_window">
+        <field name="name">Import MDM Khách hàng</field>
+        <field name="res_model">mdm.khach.hang.import.wizard</field>
+        <field name="view_mode">form</field>
+        <field name="target">new</field>
+    </record>
+</odoo>

--- a/sonha_mdm/views/menu_views.xml
+++ b/sonha_mdm/views/menu_views.xml
@@ -21,6 +21,12 @@
               action="action_mdm_tong_hop_import_excel_wizard"
               sequence="3"/>
 
+    <menuitem id="menu_mdm_khach_hang_import_excel"
+              name="Import MDM Khách hàng"
+              parent="menu_sonha_mdm"
+              action="action_mdm_khach_hang_import_excel_wizard"
+              sequence="4"/>
+
     <menuitem id="menu_mdm_danh_muc"
               name="Danh mục"
               parent="menu_sonha_mdm"


### PR DESCRIPTION
### Motivation
- Cần một luồng import Excel tương tự import hàng hóa để nạp dữ liệu danh mục khách hàng (tạo mới hoặc cập nhật theo `ma_khach`) với các trường yêu cầu trong template.
- Import phải tự động tìm/khởi tạo các bản ghi danh mục liên quan khi chưa tồn tại để giảm công tác chuẩn bị dữ liệu trước import.

### Description
- Thêm transient wizard `mdm.khach.hang.import.wizard` với method `action_import` để đọc file Excel bằng `openpyxl`, chuẩn hóa dữ liệu và thực hiện create/update theo `ma_khach`.
- Ánh xạ các cột template vào các trường: `ma_khach`, `ten_khach`, `dia_chi_khach`, `phuong_xa_cu`, `quan_huyen_cu`, `tinh_cu`, `dat_nuoc`, `so_dien_thoai`, `mst`, `plan`, `ma_cn`, `nhom_khach`, `dvcs`, `ten_salesman`, `vung`, `qlv`, `khu_vuc`, `mien_lon`, `mien_nho`.
- Thêm helper `_clean_value`, `_find_or_create_by_name` và `_find_or_create_salesman` để chuẩn hóa và tự tạo các bản ghi danh mục khi cần.
- Thêm view form và action (`sonha_mdm/views/mdm_khach_hang_import_wizard_views.xml`) cùng menu item `Import MDM Khách hàng`, và đăng ký wizard trong `sonha_mdm/models/__init__.py` và `sonha_mdm/__manifest__.py`.

### Testing
- Ran syntax check with `python -m py_compile sonha_mdm/models/mdm_khach_hang_import_wizard.py` and it completed successfully.
- No other automated unit/integration tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a069823a0b08324ac5c24a227a596fb)