### PR TITLE
Add access rule for mien.lon to fix customer import permission error

### DIFF
--- a/sonha_mdm/security/ir.model.access.csv
+++ b/sonha_mdm/security/ir.model.access.csv
@@ -33,6 +33,7 @@ access_phuong_xa_cu,phuong.xa.cu,model_phuong_xa_cu,,1,1,1,1
 access_quan_huyen_cu,quan.huyen.cu,model_quan_huyen_cu,,1,1,1,1
 access_tinh_cu,tinh.cu,model_tinh_cu,,1,1,1,1
 access_mdm_plan,mdm.plan,model_mdm_plan,,1,1,1,1
+access_mien_lon,mien.lon,model_mien_lon,,1,1,1,1
 access_mien_nho,mien.nho,model_mien_nho,,1,1,1,1
 
 access_mdm_tong_hop_import_wizard,mdm.tong.hop.import.wizard,model_mdm_tong_hop_import_wizard,,1,1,1,1


### PR DESCRIPTION
### Motivation
- The customer import wizard calls `_find_or_create_by_name('mien.lon', ...)` and failed with permission errors because there was no `ir.model.access` entry for the `mien.lon` model.

### Description
- Added an access control CSV entry `access_mien_lon,mien.lon,model_mien_lon,,1,1,1,1` to `sonha_mdm/security/ir.model.access.csv` to grant read/write/create/delete rights for `mien.lon`.

### Testing
- Verified the addition by running `rg -n "mien\.lon|import khách|Import hoàn tất|access.*mien" .` and inspecting the file lines with `nl -ba sonha_mdm/security/ir.model.access.csv | sed -n '28,45p'`, which show the new `access_mien_lon` entry.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a069e452bc48324a6dfb80774815c75)