### PR TITLE
Validate M2O by `ma` and stop auto-creating refs in product/customer import wizards

### DIFF
--- a/sonha_mdm/models/mdm_khach_hang_import_wizard.py
+++ b/sonha_mdm/models/mdm_khach_hang_import_wizard.py
@@ -25,27 +25,16 @@ class MDMKhachHangImportWizard(models.TransientModel):
             return value or False
         return str(value).strip() or False
 
-    def _find_or_create_by_name(self, model_name, value):
-        name = self._clean_value(value)
-        if not name:
+    def _find_many2one_by_code(self, model_name, value, field_label):
+        code = self._clean_value(value)
+        if not code:
             return self.env[model_name].browse()
 
-        record = self.env[model_name].search([('ten', '=', name)], limit=1)
+        record = self.env[model_name].search([('ma', '=', code)], limit=1)
         if record:
             return record
 
-        return self.env[model_name].create({'ten': name, 'ma': name})
-
-    def _find_or_create_salesman(self, code):
-        code = self._clean_value(code)
-        if not code:
-            return self.env['mdm.saleman'].browse()
-
-        record = self.env['mdm.saleman'].search([('ma', '=', code)], limit=1)
-        if record:
-            return record
-
-        return self.env['mdm.saleman'].create({'ma': code, 'ten': code})
+        raise ValidationError(_('Không tìm thấy dữ liệu ở field %(field)s với mã "%(code)s".', field=field_label, code=code))
 
     def action_import(self):
         self.ensure_one()
@@ -75,22 +64,22 @@ class MDMKhachHangImportWizard(models.TransientModel):
                     'ma_khach': ma_khach,
                     'ten_khach': ten_khach,
                     'dia_chi_khach': self._clean_value(row[2] if len(row) > 2 else False),
-                    'phuong_xa_cu': self._find_or_create_by_name('phuong.xa.cu', row[3] if len(row) > 3 else False).id,
-                    'quan_huyen_cu': self._find_or_create_by_name('quan.huyen.cu', row[4] if len(row) > 4 else False).id,
-                    'tinh_cu': self._find_or_create_by_name('tinh.cu', row[5] if len(row) > 5 else False).id,
-                    'dat_nuoc': self._find_or_create_by_name('mdm.quoc.gia', row[6] if len(row) > 6 else False).id,
+                    'phuong_xa_cu': self._find_many2one_by_code('phuong.xa.cu', row[3] if len(row) > 3 else False, 'Phường/xã cũ').id,
+                    'quan_huyen_cu': self._find_many2one_by_code('quan.huyen.cu', row[4] if len(row) > 4 else False, 'Quận/huyện cũ').id,
+                    'tinh_cu': self._find_many2one_by_code('tinh.cu', row[5] if len(row) > 5 else False, 'Tỉnh cũ').id,
+                    'dat_nuoc': self._find_many2one_by_code('mdm.quoc.gia', row[6] if len(row) > 6 else False, 'Đất nước').id,
                     'so_dien_thoai': self._clean_value(row[7] if len(row) > 7 else False),
                     'mst': self._clean_value(row[8] if len(row) > 8 else False),
-                    'plan': self._find_or_create_by_name('mdm.plan', row[9] if len(row) > 9 else False).id,
-                    'ma_cn': self._find_or_create_by_name('mdm.chi.nhanh', row[10] if len(row) > 10 else False).id,
-                    'nhom_khach': self._find_or_create_by_name('mdm.nhom.khach', row[11] if len(row) > 11 else False).id,
+                    'plan': self._find_many2one_by_code('mdm.plan', row[9] if len(row) > 9 else False, 'Plan').id,
+                    'ma_cn': self._find_many2one_by_code('mdm.chi.nhanh', row[10] if len(row) > 10 else False, 'Mã chi nhánh').id,
+                    'nhom_khach': self._find_many2one_by_code('mdm.nhom.khach', row[11] if len(row) > 11 else False, 'Nhóm khách').id,
                     'dvcs': self.env.company.id,
-                    'ten_salesman': self._find_or_create_salesman(row[13] if len(row) > 13 else False).id,
+                    'ten_salesman': self._find_many2one_by_code('mdm.saleman', row[13] if len(row) > 13 else False, 'Tên Salesman').id,
                     'vung': self._clean_value(row[14] if len(row) > 14 else False),
-                    'qlv': self._find_or_create_by_name('mdm.quan.ly.vung', row[15] if len(row) > 15 else False).id,
-                    'khu_vuc': self._find_or_create_by_name('mdm.khu.vuc', row[16] if len(row) > 16 else False).id,
-                    'mien_lon': self._find_or_create_by_name('mien.lon', row[17] if len(row) > 17 else False).id,
-                    'mien_nho': self._find_or_create_by_name('mien.nho', row[18] if len(row) > 18 else False).id,
+                    'qlv': self._find_many2one_by_code('mdm.quan.ly.vung', row[15] if len(row) > 15 else False, 'QLV').id,
+                    'khu_vuc': self._find_many2one_by_code('mdm.khu.vuc', row[16] if len(row) > 16 else False, 'Khu vực').id,
+                    'mien_lon': self._find_many2one_by_code('mien.lon', row[17] if len(row) > 17 else False, 'Miền lớn').id,
+                    'mien_nho': self._find_many2one_by_code('mien.nho', row[18] if len(row) > 18 else False, 'Miền nhỏ').id,
                 }
 
                 existing = model.search([('ma_khach', '=', ma_khach)], limit=1) if ma_khach else model.browse()

--- a/sonha_mdm/models/mdm_tong_hop_import_wizard.py
+++ b/sonha_mdm/models/mdm_tong_hop_import_wizard.py
@@ -25,25 +25,14 @@ class MDMTongHopImportWizard(models.TransientModel):
             return value or False
         return str(value).strip() or False
 
-    def _find_by_code(self, model_name, code):
+    def _find_many2one_by_code(self, model_name, code, field_label):
         code = self._clean_value(code)
         if not code:
             return self.env[model_name].browse()
-        return self.env[model_name].search([('ma', '=', code)], limit=1)
-
-    def _find_or_create_by_code(self, model_name, code):
-        code = self._clean_value(code)
-        if not code:
-            return self.env[model_name].browse()
-
-        record = self._find_by_code(model_name, code)
+        record = self.env[model_name].search([('ma', '=', code)], limit=1)
         if record:
             return record
-
-        return self.env[model_name].create({
-            'ma': code,
-            'ten': code,
-        })
+        raise ValidationError(_('Không tìm thấy dữ liệu ở field %(field)s với mã "%(code)s".', field=field_label, code=code))
 
     def action_import(self):
         self.ensure_one()
@@ -70,21 +59,21 @@ class MDMTongHopImportWizard(models.TransientModel):
 
             vals = {
                 'ma_tg': ma_tg,
-                'mdm_hh_type_id': self._find_or_create_by_code('mdm.hh.type', row[1] if len(row) > 1 else False).id,
+                'mdm_hh_type_id': self._find_many2one_by_code('mdm.hh.type', row[1] if len(row) > 1 else False, 'Loại hàng hóa').id,
                 'ten_ngan': self._clean_value(row[2] if len(row) > 2 else False),
                 'ten': self._clean_value(row[3] if len(row) > 3 else False),
                 'dvt': self._clean_value(row[4] if len(row) > 4 else False),
-                'chung_loai1': self._find_or_create_by_code('mdm.chung.loai1', row[5] if len(row) > 5 else False).id,
-                'chung_loai2': self._find_or_create_by_code('mdm.chung.loai2', row[6] if len(row) > 6 else False).id,
-                'linh_vuc': self._find_or_create_by_code('mdm.linh.vuc', row[7] if len(row) > 7 else False).id,
-                'nganh_hang': self._find_or_create_by_code('mdm.nganh.hang', row[8] if len(row) > 8 else False).id,
-                'nhan_hang': self._find_or_create_by_code('mdm.nhan.hang', row[9] if len(row) > 9 else False).id,
-                'chat_lieu': self._find_or_create_by_code('mdm.chat.lieu', row[10] if len(row) > 10 else False).id,
-                'do_bong': self._find_or_create_by_code('mdm.do.bong', row[11] if len(row) > 11 else False).id,
-                'do_day': self._find_or_create_by_code('mdm.do.day', row[12] if len(row) > 12 else False).id,
+                'chung_loai1': self._find_many2one_by_code('mdm.chung.loai1', row[5] if len(row) > 5 else False, 'Chủng loại 1').id,
+                'chung_loai2': self._find_many2one_by_code('mdm.chung.loai2', row[6] if len(row) > 6 else False, 'Chủng loại 2').id,
+                'linh_vuc': self._find_many2one_by_code('mdm.linh.vuc', row[7] if len(row) > 7 else False, 'Lĩnh vực').id,
+                'nganh_hang': self._find_many2one_by_code('mdm.nganh.hang', row[8] if len(row) > 8 else False, 'Ngành hàng').id,
+                'nhan_hang': self._find_many2one_by_code('mdm.nhan.hang', row[9] if len(row) > 9 else False, 'Nhãn hàng').id,
+                'chat_lieu': self._find_many2one_by_code('mdm.chat.lieu', row[10] if len(row) > 10 else False, 'Chất liệu').id,
+                'do_bong': self._find_many2one_by_code('mdm.do.bong', row[11] if len(row) > 11 else False, 'Độ bóng').id,
+                'do_day': self._find_many2one_by_code('mdm.do.day', row[12] if len(row) > 12 else False, 'Độ dày').id,
                 'dung_tich_plus': self._clean_value(row[13] if len(row) > 13 else False),
                 'dvt_dung_tich': self._clean_value(row[14] if len(row) > 14 else False),
-                'bom_sale': self._find_or_create_by_code('bom.sale', row[15] if len(row) > 15 else False).id,
+                'bom_sale': self._find_many2one_by_code('bom.sale', row[15] if len(row) > 15 else False, 'Loại trong BOM sales').id,
             }
 
             try:
@@ -104,4 +93,3 @@ class MDMTongHopImportWizard(models.TransientModel):
             raise ValidationError(message)
 
         return {'type': 'ir.actions.act_window_close'}
-


### PR DESCRIPTION
### Motivation
- Thay đổi hành vi import cho các trường `many2one` để: nếu không nhập -> giữ `False`/null; nếu nhập -> đối chiếu theo trường `ma`; nếu không tìm thấy -> báo lỗi rõ ràng thay vì tự tạo record.
- Ngăn wizard import tạo mới dữ liệu tham chiếu tự động để đảm bảo dữ liệu liên kết chỉ đến các bản ghi đã tồn tại.

### Description
- Thay thế cơ chế tìm/tao bằng hàm mới `def _find_many2one_by_code(self, model_name, value, field_label)` trong `mdm_tong_hop_import_wizard.py` và `mdm_khach_hang_import_wizard.py` để trả về record khi `ma` tồn tại, trả `browse()` (False) khi input trống và `raise ValidationError` khi mã không tìm thấy.
- Cập nhật tất cả lookup `many2one` trong `mdm.tong.hop.import.wizard` (ví dụ `mdm_hh_type_id`, `chung_loai1`, `chung_loai2`, `linh_vuc`, `nganh_hang`, `nhan_hang`, `chat_lieu`, `do_bong`, `do_day`, `bom_sale`) để dùng `self._find_many2one_by_code(..., '<Field label>')` và lấy `.id`.
- Cập nhật tất cả lookup `many2one` trong `mdm.khach.hang.import.wizard` (ví dụ `phuong_xa_cu`, `quan_huyen_cu`, `tinh_cu`, `dat_nuoc`, `plan`, `ma_cn`, `nhom_khach`, `ten_salesman`, `qlv`, `khu_vuc`, `mien_lon`, `mien_nho`) để dùng `self._find_many2one_by_code(..., '<Field label>')` và bỏ cơ chế tự tạo bản ghi.
- Thông báo lỗi khi không tìm thấy mã bao gồm tên field và mã không tồn tại bằng `ValidationError` (ví dụ: `Không tìm thấy dữ liệu ở field <Field> với mã "<code>".`).

### Testing
- Chạy biên dịch kiểm tra cú pháp với `python -m py_compile sonha_mdm/models/mdm_tong_hop_import_wizard.py sonha_mdm/models/mdm_khach_hang_import_wizard.py` and it passed successfully.
- No other automated tests were added or run in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06d3e2d8188324a2140d295701d450)