### PR TITLE
[IMP] sonha_mdm: cập nhật import hàng hóa/khách hàng theo cột ID

### DIFF
--- a/sonha_mdm/models/mdm_khach_hang_import_wizard.py
+++ b/sonha_mdm/models/mdm_khach_hang_import_wizard.py
@@ -56,7 +56,8 @@ class MDMKhachHangImportWizard(models.TransientModel):
         for row_index, row in enumerate(sheet.iter_rows(min_row=2, values_only=True), start=2):
             ma_khach = self._clean_value(row[0] if len(row) > 0 else False)
             ten_khach = self._clean_value(row[1] if len(row) > 1 else False)
-            if not ma_khach and not ten_khach:
+            record_id = self._clean_value(row[19] if len(row) > 19 else False)
+            if not any(self._clean_value(cell) for cell in row[:19]) and not record_id:
                 continue
 
             try:
@@ -82,7 +83,12 @@ class MDMKhachHangImportWizard(models.TransientModel):
                     'mien_nho': self._find_many2one_by_code('mien.nho', row[18] if len(row) > 18 else False, 'Miền nhỏ').id,
                 }
 
-                existing = model.search([('ma_khach', '=', ma_khach)], limit=1) if ma_khach else model.browse()
+                existing = model.browse()
+                if record_id:
+                    if not str(record_id).isdigit():
+                        raise ValidationError(_('ID phải là số nguyên dương.'))
+                    existing = model.search([('id', '=', int(record_id))], limit=1)
+
                 if existing:
                     existing.write(vals)
                     updated += 1
@@ -90,7 +96,7 @@ class MDMKhachHangImportWizard(models.TransientModel):
                     model.create(vals)
                     imported += 1
             except Exception as exc:
-                errors.append(_('Dòng %(row)s: %(error)s', row=row_index, error=str(exc)))
+                errors.append(_('Dòng %(row)s (ID: %(record_id)s): %(error)s', row=row_index, record_id=record_id or '-', error=str(exc)))
 
         message = _('Import hoàn tất. Tạo mới: %(new)s, Cập nhật: %(updated)s', new=imported, updated=updated)
         if errors:

--- a/sonha_mdm/models/mdm_tong_hop_import_wizard.py
+++ b/sonha_mdm/models/mdm_tong_hop_import_wizard.py
@@ -54,7 +54,9 @@ class MDMTongHopImportWizard(models.TransientModel):
 
         for row_index, row in enumerate(sheet.iter_rows(min_row=2, values_only=True), start=2):
             ma_tg = self._clean_value(row[0] if len(row) > 0 else False)
-            if not ma_tg:
+            record_id = self._clean_value(row[16] if len(row) > 16 else False)
+
+            if not any(self._clean_value(cell) for cell in row[:16]) and not record_id:
                 continue
 
             vals = {
@@ -77,7 +79,12 @@ class MDMTongHopImportWizard(models.TransientModel):
             }
 
             try:
-                existing = model.search([('ma_tg', '=', ma_tg)], limit=1)
+                existing = model.browse()
+                if record_id:
+                    if not str(record_id).isdigit():
+                        raise ValidationError(_('ID phải là số nguyên dương.'))
+                    existing = model.search([('id', '=', int(record_id))], limit=1)
+
                 if existing:
                     existing.write(vals)
                     updated += 1
@@ -85,7 +92,7 @@ class MDMTongHopImportWizard(models.TransientModel):
                     model.create(vals)
                     imported += 1
             except Exception as exc:
-                errors.append(_('Dòng %(row)s (Mã TG: %(ma_tg)s): %(error)s', row=row_index, ma_tg=ma_tg, error=str(exc)))
+                errors.append(_('Dòng %(row)s (Mã TG: %(ma_tg)s, ID: %(record_id)s): %(error)s', row=row_index, ma_tg=ma_tg, record_id=record_id or '-', error=str(exc)))
 
         message = _('Import hoàn tất. Tạo mới: %(new)s, Cập nhật: %(updated)s', new=imported, updated=updated)
         if errors:


### PR DESCRIPTION
### Motivation
- Thay đổi cơ chế xác định bản ghi khi import để có thể cập nhật trực tiếp theo `id` đưa trong file thay vì chỉ dựa trên `ma_tg`/`ma_khach`.

### Description
- Cập nhật `mdm_tong_hop_import_wizard.py` để đọc `id` từ cột cuối (index 16) và nếu có thì tìm theo `id` để cập nhật, nếu không có thì tạo mới; bỏ dò trùng theo `ma_tg` và thêm `ID` vào thông báo lỗi mỗi dòng.
- Cập nhật `mdm_khach_hang_import_wizard.py` để đọc `id` từ cột cuối (index 19) và nếu có thì tìm theo `id` để cập nhật, nếu không có thì tạo mới; bỏ dò trùng theo `ma_khach` và thêm `ID` vào thông báo lỗi mỗi dòng.
- Bổ sung kiểm tra `id` phải là số nguyên dương, và điều chỉnh logic bỏ qua dòng trống để không tính cột `id` là nội dung bắt buộc.
- Thay đổi được lưu vào hai file: `sonha_mdm/models/mdm_tong_hop_import_wizard.py` và `sonha_mdm/models/mdm_khach_hang_import_wizard.py`.

### Testing
- Chạy kiểm tra cú pháp Python cho 2 file đã chỉnh sửa bằng `python -m py_compile sonha_mdm/models/mdm_khach_hang_import_wizard.py sonha_mdm/models/mdm_tong_hop_import_wizard.py` và kết quả: pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06d5ae3a408324a6dd0a59adff6c26)