### PR TITLE
Auto-generate `ma` for new `mdm.tong.hop` records (mdm01 + zero-padded id)

### DIFF
--- a/sonha_mdm/models/mdm_tong_hop.py
+++ b/sonha_mdm/models/mdm_tong_hop.py
@@ -283,6 +283,8 @@ class MDMTongHop(models.Model):
     @api.model
     def create(self, vals):
         record = super().create(vals)
+        if not record.ma:
+            record.ma = f"mdm01{record.id:010d}"
         self.create_write_action_data(record)
         self.call_api_insert(record)
 


### PR DESCRIPTION
### Motivation
- Tự động sinh trường `ma` cho bản ghi hàng hóa mới theo quy tắc `mdm01` + 10 chữ số từ `id` để đảm bảo mã định danh nhất quán (ví dụ `id=1` -> `mdm010000000001`).

### Description
- Thêm logic vào phương thức `create` của model `mdm.tong.hop` để nếu `ma` rỗng thì gán `record.ma = f"mdm01{record.id:010d}"` trước khi gọi `create_write_action_data` và `call_api_insert`.

### Testing
- Đã chạy `python -m py_compile sonha_mdm/models/mdm_tong_hop.py` và biên dịch thành công.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d15e495dc83248782d8a017115a5b)