### PR TITLE
[sonha_mdm] Add child table `mdm.tong.hop.line` for per-company MDM codes

### DIFF
--- a/sonha_mdm/models/__init__.py
+++ b/sonha_mdm/models/__init__.py
@@ -31,3 +31,4 @@ from . import mdm_tong_hop_import_wizard
 from . import mdm_khach_hang_import_wizard
 
 from . import bom_sale
+from . import mdm_tong_hop_line

--- a/sonha_mdm/models/mdm_tong_hop.py
+++ b/sonha_mdm/models/mdm_tong_hop.py
@@ -64,6 +64,7 @@ class MDMTongHop(models.Model):
     dvcs = fields.Many2one('res.company', string="ĐV", store=True, default=lambda self: self.env.company, readonly=False)
     luong_duyet = fields.Many2one('luong.duyet', string="Luồng duyệt")
     buoc_duyet = fields.One2many('buoc.duyet.hang.hoa', 'key', string="Bước duyệt")
+    bang_con_ids = fields.One2many('mdm.tong.hop.line', 'tong_hop_id', string='Bảng con đơn vị')
 
     current_step = fields.Integer(string="STT hiện tại", default=1)
     can_approve = fields.Boolean(compute='_compute_can_approve')

--- a/sonha_mdm/models/mdm_tong_hop_line.py
+++ b/sonha_mdm/models/mdm_tong_hop_line.py
@@ -1,0 +1,11 @@
+from odoo import fields, models
+
+
+class MDMTongHopLine(models.Model):
+    _name = 'mdm.tong.hop.line'
+    _description = 'Bảng con MDM hàng hóa'
+
+    tong_hop_id = fields.Many2one('mdm.tong.hop', string='Hàng hóa', required=True, ondelete='cascade')
+    ma_mdm = fields.Char(string='Mã MDM')
+    ma_dv = fields.Char(string='Mã đơn vị')
+    dvcs = fields.Many2one('res.company', string='ĐVCS')

--- a/sonha_mdm/security/ir.model.access.csv
+++ b/sonha_mdm/security/ir.model.access.csv
@@ -41,3 +41,4 @@ access_bom_sale,bom.sale,model_bom_sale,,1,1,1,1
 
 access_mdm_khach_hang_import_wizard,mdm.khach.hang.import.wizard,model_mdm_khach_hang_import_wizard,,1,1,1,1
 
+access_mdm_tong_hop_line,mdm.tong.hop.line,model_mdm_tong_hop_line,,1,1,1,1

--- a/sonha_mdm/views/mdm_tong_hop_views.xml
+++ b/sonha_mdm/views/mdm_tong_hop_views.xml
@@ -54,6 +54,15 @@
                         </tree>
                     </field>
                     </page>
+                    <page string="Bảng con đơn vị">
+                        <field name="bang_con_ids">
+                            <tree editable="bottom">
+                                <field name="ma_mdm"/>
+                                <field name="ma_dv"/>
+                                <field name="dvcs"/>
+                            </tree>
+                        </field>
+                    </page>
                     <page string="Bước duyệt">
                         <field name="buoc_duyet">
                             <tree>


### PR DESCRIPTION
### Motivation
- Provide a per-company child table for MDM goods to store unit-specific codes and company linkage (`ma_mdm`, `ma_dv`, `dvcs`) linked to the parent goods record.

### Description
- Add new model `mdm.tong.hop.line` in `sonha_mdm/models/mdm_tong_hop_line.py` with fields `tong_hop_id` (Many2one -> `mdm.tong.hop`), `ma_mdm`, `ma_dv`, and `dvcs` (Many2one -> `res.company`).
- Expose a One2many `bang_con_ids = fields.One2many('mdm.tong.hop.line', 'tong_hop_id')` on the parent model `mdm.tong.hop` in `sonha_mdm/models/mdm_tong_hop.py`.
- Add an editable notebook page `Bảng con đơn vị` to the `mdm.tong.hop` form view to manage child rows (`ma_mdm`, `ma_dv`, `dvcs`) in `sonha_mdm/views/mdm_tong_hop_views.xml`.
- Register the new model in `sonha_mdm/models/__init__.py` and add access rights entry in `sonha_mdm/security/ir.model.access.csv`.

### Testing
- Ran `python -m py_compile sonha_mdm/models/mdm_tong_hop.py sonha_mdm/models/mdm_tong_hop_line.py sonha_mdm/models/__init__.py` and compilation succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d22050f508324ab947feb866a0f6d)