### PR TITLE
Update MDM goods import to new Excel template and match by MDM code

### DIFF
--- a/sonha_mdm/models/mdm_tong_hop_import_wizard.py
+++ b/sonha_mdm/models/mdm_tong_hop_import_wizard.py
@@ -53,37 +53,37 @@ class MDMTongHopImportWizard(models.TransientModel):
         errors = []
 
         for row_index, row in enumerate(sheet.iter_rows(min_row=2, values_only=True), start=2):
-            ma_tg = self._clean_value(row[0] if len(row) > 0 else False)
-            record_id = self._clean_value(row[16] if len(row) > 16 else False)
+            ma_tg = self._clean_value(row[1] if len(row) > 1 else False)
+            ma_mdm = self._clean_value(row[2] if len(row) > 2 else False)
 
-            if not any(self._clean_value(cell) for cell in row[:16]) and not record_id:
+            if not any(self._clean_value(cell) for cell in row[:18]):
                 continue
 
             vals = {
                 'ma_tg': ma_tg,
-                'mdm_hh_type_id': self._find_many2one_by_code('mdm.hh.type', row[1] if len(row) > 1 else False, 'Loại hàng hóa').id,
-                'ten_ngan': self._clean_value(row[2] if len(row) > 2 else False),
-                'ten': self._clean_value(row[3] if len(row) > 3 else False),
-                'dvt': self._clean_value(row[4] if len(row) > 4 else False),
-                'chung_loai1': self._find_many2one_by_code('mdm.chung.loai1', row[5] if len(row) > 5 else False, 'Chủng loại 1').id,
-                'chung_loai2': self._find_many2one_by_code('mdm.chung.loai2', row[6] if len(row) > 6 else False, 'Chủng loại 2').id,
-                'linh_vuc': self._find_many2one_by_code('mdm.linh.vuc', row[7] if len(row) > 7 else False, 'Lĩnh vực').id,
-                'nganh_hang': self._find_many2one_by_code('mdm.nganh.hang', row[8] if len(row) > 8 else False, 'Ngành hàng').id,
-                'nhan_hang': self._find_many2one_by_code('mdm.nhan.hang', row[9] if len(row) > 9 else False, 'Nhãn hàng').id,
-                'chat_lieu': self._find_many2one_by_code('mdm.chat.lieu', row[10] if len(row) > 10 else False, 'Chất liệu').id,
-                'do_bong': self._find_many2one_by_code('mdm.do.bong', row[11] if len(row) > 11 else False, 'Độ bóng').id,
-                'do_day': self._find_many2one_by_code('mdm.do.day', row[12] if len(row) > 12 else False, 'Độ dày').id,
-                'dung_tich_plus': self._clean_value(row[13] if len(row) > 13 else False),
-                'dvt_dung_tich': self._clean_value(row[14] if len(row) > 14 else False),
-                'bom_sale': self._find_many2one_by_code('bom.sale', row[15] if len(row) > 15 else False, 'Loại trong BOM sales').id,
+                'ma': ma_mdm,
+                'mdm_hh_type_id': self._find_many2one_by_code('mdm.hh.type', row[3] if len(row) > 3 else False, 'Loại hàng hóa').id,
+                'ten_ngan': self._clean_value(row[4] if len(row) > 4 else False),
+                'ten': self._clean_value(row[5] if len(row) > 5 else False),
+                'dvt': self._clean_value(row[6] if len(row) > 6 else False),
+                'chung_loai1': self._find_many2one_by_code('mdm.chung.loai1', row[7] if len(row) > 7 else False, 'Chủng loại 1').id,
+                'chung_loai2': self._find_many2one_by_code('mdm.chung.loai2', row[8] if len(row) > 8 else False, 'Chủng loại 2').id,
+                'linh_vuc': self._find_many2one_by_code('mdm.linh.vuc', row[9] if len(row) > 9 else False, 'Lĩnh vực').id,
+                'nganh_hang': self._find_many2one_by_code('mdm.nganh.hang', row[10] if len(row) > 10 else False, 'Ngành hàng').id,
+                'nhan_hang': self._find_many2one_by_code('mdm.nhan.hang', row[11] if len(row) > 11 else False, 'Nhãn hàng').id,
+                'chat_lieu': self._find_many2one_by_code('mdm.chat.lieu', row[12] if len(row) > 12 else False, 'Chất liệu').id,
+                'do_bong': self._find_many2one_by_code('mdm.do.bong', row[13] if len(row) > 13 else False, 'Độ bóng').id,
+                'do_day': self._find_many2one_by_code('mdm.do.day', row[14] if len(row) > 14 else False, 'Độ dày').id,
+                'dung_tich_plus': self._clean_value(row[15] if len(row) > 15 else False),
+                'dvt_dung_tich': self._clean_value(row[16] if len(row) > 16 else False),
+                'bom_sale': self._find_many2one_by_code('bom.sale', row[17] if len(row) > 17 else False, 'Loại trong BOM sales').id,
             }
 
             try:
-                existing = model.browse()
-                if record_id:
-                    if not str(record_id).isdigit():
-                        raise ValidationError(_('ID phải là số nguyên dương.'))
-                    existing = model.search([('id', '=', int(record_id))], limit=1)
+                if not ma_mdm:
+                    raise ValidationError(_('Thiếu Mã MDM ở cột C.'))
+
+                existing = model.search([('ma', '=', ma_mdm)], limit=1)
 
                 if existing:
                     existing.write(vals)
@@ -92,7 +92,7 @@ class MDMTongHopImportWizard(models.TransientModel):
                     model.create(vals)
                     imported += 1
             except Exception as exc:
-                errors.append(_('Dòng %(row)s (Mã TG: %(ma_tg)s, ID: %(record_id)s): %(error)s', row=row_index, ma_tg=ma_tg, record_id=record_id or '-', error=str(exc)))
+                errors.append(_('Dòng %(row)s (Mã MDM: %(ma_mdm)s): %(error)s', row=row_index, ma_mdm=ma_mdm or '-', error=str(exc)))
 
         message = _('Import hoàn tất. Tạo mới: %(new)s, Cập nhật: %(updated)s', new=imported, updated=updated)
         if errors:


### PR DESCRIPTION
### Motivation
- Align the MDM goods Excel import with the new template (user-provided) so columns map correctly to model fields. 
- Use the MDM code (`ma`) from the Excel file as the matching key instead of relying on an Excel `id` to update existing records. 
- Surface clear validation when `Mã MDM` is missing and provide error context keyed by `Mã MDM` for easier troubleshooting.

### Description
- Modified `sonha_mdm/models/mdm_tong_hop_import_wizard.py` to change the import column mapping to the new layout and to set `ma_tg` from column B and `ma` (MDM code) from column C. 
- Shifted subsequent field mappings one column to the right (now reading business fields from columns D..R) and updated the empty-row detection to inspect the first 18 columns. 
- Replaced the previous update-by-`id` logic with a lookup by `('ma', '=', ma_mdm)` and updated/create accordingly. 
- Added validation to raise `ValidationError` when `Mã MDM` (column C) is missing and changed error messages to report `Mã MDM` in the import error context.

### Testing
- Ran `python -m py_compile sonha_mdm/models/mdm_tong_hop_import_wizard.py` and it completed without syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d55cd51548324bbe45cde7c237519)