### PR TITLE
[sonha_mdm] Import hàng hóa: tạo/bỏ trùng bản ghi cha theo mã MDM và thêm dòng đơn vị

### DIFF
--- a/sonha_mdm/models/mdm_tong_hop_import_wizard.py
+++ b/sonha_mdm/models/mdm_tong_hop_import_wizard.py
@@ -47,6 +47,7 @@ class MDMTongHopImportWizard(models.TransientModel):
         sheet = workbook.active
 
         model = self.env['mdm.tong.hop']
+        line_model = self.env['mdm.tong.hop.line']
 
         imported = 0
         updated = 0
@@ -86,11 +87,18 @@ class MDMTongHopImportWizard(models.TransientModel):
                 existing = model.search([('ma', '=', ma_mdm)], limit=1)
 
                 if existing:
-                    existing.write(vals)
+                    parent_record = existing
                     updated += 1
                 else:
-                    model.create(vals)
+                    parent_record = model.create(vals)
                     imported += 1
+
+                line_model.create({
+                    'tong_hop_id': parent_record.id,
+                    'ma_mdm': ma_mdm,
+                    'ma_dv': ma_tg,
+                    'dvcs': self.env.company.id,
+                })
             except Exception as exc:
                 errors.append(_('Dòng %(row)s (Mã MDM: %(ma_mdm)s): %(error)s', row=row_index, ma_mdm=ma_mdm or '-', error=str(exc)))
 


### PR DESCRIPTION
### Motivation
- Đồng bộ hóa logic import để khi import theo `mã MDM` không tạo trùng bản ghi cha và luôn thêm dòng đơn vị vào bảng con khi có dữ liệu import.

### Description
- Thay đổi `action_import` trong `mdm.tong.hop.import.wizard` để khởi tạo `line_model = self.env['mdm.tong.hop.line']` và dùng `parent_record` làm bản ghi cha cho dòng con. 
- Nếu `ma` (mã MDM) tồn tại thì không tạo bản ghi `mdm.tong.hop` mới và gán `parent_record = existing`, nếu không tồn tại thì `parent_record = model.create(vals)`.
- Sau khi xác định `parent_record` luôn tạo 1 dòng con bằng `line_model.create({...})` với các trường `tong_hop_id`, `ma_mdm`, `ma_dv`, `dvcs` (gán `dvcs` = `self.env.company.id`).
- Thay đổi được thực hiện trong file `sonha_mdm/models/mdm_tong_hop_import_wizard.py` và giữ nguyên ý nghĩa bộ đếm `Tạo mới` (`imported`) và `Cập nhật` (`updated`).

### Testing
- Không có bài kiểm thử tự động nào được chạy cho thay đổi này.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d582948d48324abcfeb572eec7a9b)