### PR TITLE
Import wizards: preserve existing values when incoming fields are empty

### DIFF
--- a/sonha_master_data/wizard/wizard_import_infor.py
+++ b/sonha_master_data/wizard/wizard_import_infor.py
@@ -14,6 +14,19 @@ class WizardImportInfor(models.TransientModel):
                               ('vendor', "Nhà cung cấp"),
                               ('material', "Vật tư")], string="Model")
 
+
+
+    @staticmethod
+    def _build_partial_update_vals(current_record, incoming_vals):
+        """Only overwrite fields having non-empty values in import file."""
+        vals = {}
+        for field_name, value in incoming_vals.items():
+            if value not in (None, ''):
+                vals[field_name] = value
+            elif current_record:
+                vals[field_name] = current_record[field_name]
+        return vals
+
     def action_confirm(self):
         file_stream = io.BytesIO(base64.b64decode(self.file))
         wb = load_workbook(filename=file_stream, data_only=True)
@@ -248,6 +261,40 @@ class WizardImportInfor(models.TransientModel):
                         'indicator': indicator_bool,
                     }
                     self.env['vendor.purchase'].sudo().create(vals)
+                row += 1
+
+        if self.model == 'material':
+            sheet = wb['Sheet1']
+            max_row = sheet.max_row
+            row = 2
+            while row <= max_row:
+                mdm_code = sheet.cell(row=row, column=1).value
+                if mdm_code:
+                    product_type = self.env['x.material.type'].sudo().search([('x_code', '=', sheet.cell(row=row, column=2).value)], limit=1)
+                    product_name = sheet.cell(row=row, column=3).value
+                    product_english_name = sheet.cell(row=row, column=4).value
+                    product_long_name = sheet.cell(row=row, column=5).value
+                    search_product = self.env['md.product'].sudo().search([('product_code', '=', mdm_code)], limit=1)
+                    incoming_vals = {
+                        'product_code': mdm_code,
+                        'product_type': product_type.id,
+                        'product_name': product_name,
+                        'product_english_name': product_english_name,
+                        'product_long_name': product_long_name,
+                    }
+                    if search_product:
+                        update_vals = self._build_partial_update_vals(search_product, incoming_vals)
+                        search_product.sudo().write(update_vals)
+                        self.env['basic.mat.data'].sudo().create({
+                            'md_product_id': search_product.id,
+                            'old_product_code': mdm_code,
+                        })
+                    else:
+                        new_product = self.env['md.product'].sudo().create(incoming_vals)
+                        self.env['basic.mat.data'].sudo().create({
+                            'md_product_id': new_product.id,
+                            'old_product_code': mdm_code,
+                        })
                 row += 1
         return {
             'type': 'ir.actions.client',

--- a/sonha_mdm/models/mdm_tong_hop_import_wizard.py
+++ b/sonha_mdm/models/mdm_tong_hop_import_wizard.py
@@ -34,6 +34,17 @@ class MDMTongHopImportWizard(models.TransientModel):
             return record
         raise ValidationError(_('Không tìm thấy dữ liệu ở field %(field)s với mã "%(code)s".', field=field_label, code=code))
 
+
+    @staticmethod
+    def _merge_non_empty_vals(existing_record, incoming_vals):
+        merged_vals = {}
+        for field_name, value in incoming_vals.items():
+            if value not in (False, None, ''):
+                merged_vals[field_name] = value
+            elif existing_record:
+                merged_vals[field_name] = existing_record[field_name]
+        return merged_vals
+
     def action_import(self):
         self.ensure_one()
 
@@ -108,7 +119,8 @@ class MDMTongHopImportWizard(models.TransientModel):
 
                 if existing:
                     parent_record = existing
-                    parent_record.sudo().write(dict(vals, dvcs=company.id))
+                    update_vals = self._merge_non_empty_vals(existing, vals)
+                    parent_record.sudo().write(dict(update_vals, dvcs=company.id))
                     updated += 1
                 else:
                     parent_record = model.create(dict(vals, dvcs=company.id))


### PR DESCRIPTION
### Motivation
- Ensure imports do not clobber existing record fields when the incoming Excel file has empty cells for those fields.
- Apply partial-update behavior to both the material import path and the MDM "tong hop" import to avoid unintended data loss during updates.

### Description
- Added `@staticmethod _build_partial_update_vals(current_record, incoming_vals)` in `sonha_master_data/wizard/wizard_import_infor.py` to only overwrite fields that have non-empty values and preserve existing values otherwise, and used it when updating `md.product` during `material` imports.
- Added `@staticmethod _merge_non_empty_vals(existing_record, incoming_vals)` in `sonha_mdm/models/mdm_tong_hop_import_wizard.py` and replaced direct `write` calls with merged values so updates to `mdm.tong.hop` keep existing field values when incoming cells are empty.
- Kept the existing create-paths intact and continued to create `basic.mat.data` records for imported or updated products, and ensured lookups use existing search patterns (with `limit=1` where appropriate).

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d6af52c4083248b004a984827ab49)