### PR TITLE
mdm: only set ma_dv in import when provided and show dvcs in child tree view

### DIFF
--- a/sonha_mdm/models/mdm_tong_hop_import_wizard.py
+++ b/sonha_mdm/models/mdm_tong_hop_import_wizard.py
@@ -85,14 +85,13 @@ class MDMTongHopImportWizard(models.TransientModel):
             raise ValidationError(_('Không tìm thấy công ty với mã công ty "%(code)s".', code=company_code))
 
         for row_index, row in enumerate(rows, start=2):
-            ma_tg = self._clean_value(row[1] if len(row) > 1 else False)
+            ma_hang_don_vi = self._clean_value(row[1] if len(row) > 1 else False)
             ma_mdm = self._clean_value(row[2] if len(row) > 2 else False)
 
             if not any(self._clean_value(cell) for cell in row[:18]):
                 continue
 
             vals = {
-                'ma_tg': ma_tg,
                 'ma': ma_mdm,
                 'mdm_hh_type_id': self._find_many2one_by_code('mdm.hh.type', row[3] if len(row) > 3 else False, 'Loại hàng hóa').id,
                 'ten_ngan': self._clean_value(row[4] if len(row) > 4 else False),
@@ -126,12 +125,15 @@ class MDMTongHopImportWizard(models.TransientModel):
                     parent_record = model.create(dict(vals, dvcs=company.id))
                     imported += 1
 
-                line_model.create({
+                line_vals = {
                     'tong_hop_id': parent_record.id,
                     'ma_mdm': ma_mdm,
-                    'ma_dv': ma_tg,
                     'dvcs': company.id,
-                })
+                }
+                if ma_hang_don_vi:
+                    line_vals['ma_dv'] = ma_hang_don_vi
+
+                line_model.create(line_vals)
             except Exception as exc:
                 errors.append(_('Dòng %(row)s (Mã MDM: %(ma_mdm)s): %(error)s', row=row_index, ma_mdm=ma_mdm or '-', error=str(exc)))
 

--- a/sonha_mdm/views/mdm_tong_hop_views.xml
+++ b/sonha_mdm/views/mdm_tong_hop_views.xml
@@ -59,6 +59,7 @@
                             <tree editable="bottom">
                                 <field name="ma_mdm"/>
                                 <field name="ma_dv"/>
+                                <field name="dvcs"/>
                             </tree>
                         </field>
                     </page>


### PR DESCRIPTION
### Motivation

- Prevent creating child lines with an empty/false `ma_dv` value when importing and make the child rows show the company (`dvcs`).
- Avoid storing a placeholder/empty unit code into the parent record import values.

### Description

- Renamed the temporary import variable to `ma_hang_don_vi` and removed `ma_tg` from the parent `vals` payload. 
- Build `line_vals` for the child line and add `ma_dv` to `line_vals` only when `ma_hang_don_vi` is present, then call `line_model.create(line_vals)`.
- Always include `dvcs` when creating/updating parent and child records during import.
- Added the `dvcs` field to the child tree in `mdm_tong_hop` views so the company is visible in the child table.

### Testing

- Ran the module test suite with `pytest` and the tests in the affected area passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d6fed31dc832480d7a8204dbfaf7a)