### PR TITLE
Add child model `mdm.khach.hang.line` and enhance `mdm.khach.hang` import wizard with company validation and merge logic

### DIFF
--- a/sonha_mdm/models/__init__.py
+++ b/sonha_mdm/models/__init__.py
@@ -32,3 +32,5 @@ from . import mdm_khach_hang_import_wizard
 
 from . import bom_sale
 from . import mdm_tong_hop_line
+
+from . import mdm_khach_hang_line

--- a/sonha_mdm/models/mdm_khach_hang.py
+++ b/sonha_mdm/models/mdm_khach_hang.py
@@ -42,6 +42,8 @@ class MDMKhachHang(models.Model):
 
     buoc_duyet = fields.One2many('buoc.duyet.khach.hang', 'key', string="Bước duyệt")
 
+    bang_con_ids = fields.One2many('mdm.khach.hang.line', 'khach_hang_id', string='Bảng con đơn vị')
+
     current_step = fields.Integer(string="STT hiện tại", default=1)
     can_approve = fields.Boolean(compute='_compute_can_approve')
 

--- a/sonha_mdm/models/mdm_khach_hang_import_wizard.py
+++ b/sonha_mdm/models/mdm_khach_hang_import_wizard.py
@@ -36,6 +36,16 @@ class MDMKhachHangImportWizard(models.TransientModel):
 
         raise ValidationError(_('Không tìm thấy dữ liệu ở field %(field)s với mã "%(code)s".', field=field_label, code=code))
 
+    @staticmethod
+    def _merge_non_empty_vals(existing_record, incoming_vals):
+        merged_vals = {}
+        for field_name, value in incoming_vals.items():
+            if value not in (False, None, ''):
+                merged_vals[field_name] = value
+            elif existing_record:
+                merged_vals[field_name] = existing_record[field_name]
+        return merged_vals
+
     def action_import(self):
         self.ensure_one()
 
@@ -48,55 +58,85 @@ class MDMKhachHangImportWizard(models.TransientModel):
         workbook = load_workbook(filename=BytesIO(base64.b64decode(self.file_data)), data_only=True)
         sheet = workbook.active
         model = self.env['mdm.khach.hang']
+        line_model = self.env['mdm.khach.hang.line']
 
         imported = 0
         updated = 0
         errors = []
 
-        for row_index, row in enumerate(sheet.iter_rows(min_row=2, values_only=True), start=2):
-            ma_khach = self._clean_value(row[0] if len(row) > 0 else False)
-            ten_khach = self._clean_value(row[1] if len(row) > 1 else False)
-            record_id = self._clean_value(row[19] if len(row) > 19 else False)
-            if not any(self._clean_value(cell) for cell in row[:19]) and not record_id:
+        rows = list(sheet.iter_rows(min_row=2, values_only=True))
+        company_codes = set()
+        for row in rows:
+            if not any(self._clean_value(cell) for cell in row[:20]):
+                continue
+            company_code = self._clean_value(row[0] if len(row) > 0 else False)
+            if company_code:
+                company_codes.add(company_code)
+
+        if len(company_codes) > 1:
+            raise ValidationError(_('File không cùng 1 mã công ty. Vui lòng kiểm tra lại cột mã công ty trong file import.'))
+
+        if not company_codes:
+            raise ValidationError(_('Thiếu mã công ty trong file import.'))
+
+        company_code = next(iter(company_codes))
+        company = self.env['res.company'].search([('company_code', '=', company_code)], limit=1)
+        if not company:
+            raise ValidationError(_('Không tìm thấy công ty với mã công ty "%(code)s".', code=company_code))
+
+        for row_index, row in enumerate(rows, start=2):
+            if not any(self._clean_value(cell) for cell in row[:20]):
                 continue
 
+            ma_kh_ncc = self._clean_value(row[1] if len(row) > 1 else False)
+            ma_mdm = self._clean_value(row[2] if len(row) > 2 else False)
+
             try:
+                if not ma_mdm:
+                    raise ValidationError(_('Thiếu Mã MDM ở cột C.'))
+
                 vals = {
-                    'ma_khach': ma_khach,
-                    'ten_khach': ten_khach,
-                    'dia_chi_khach': self._clean_value(row[2] if len(row) > 2 else False),
-                    'phuong_xa_cu': self._find_many2one_by_code('phuong.xa.cu', row[3] if len(row) > 3 else False, 'Phường/xã cũ').id,
-                    'quan_huyen_cu': self._find_many2one_by_code('quan.huyen.cu', row[4] if len(row) > 4 else False, 'Quận/huyện cũ').id,
-                    'tinh_cu': self._find_many2one_by_code('tinh.cu', row[5] if len(row) > 5 else False, 'Tỉnh cũ').id,
-                    'dat_nuoc': self._find_many2one_by_code('mdm.quoc.gia', row[6] if len(row) > 6 else False, 'Đất nước').id,
-                    'so_dien_thoai': self._clean_value(row[7] if len(row) > 7 else False),
-                    'mst': self._clean_value(row[8] if len(row) > 8 else False),
-                    'plan': self._find_many2one_by_code('mdm.plan', row[9] if len(row) > 9 else False, 'Plan').id,
-                    'ma_cn': self._find_many2one_by_code('mdm.chi.nhanh', row[10] if len(row) > 10 else False, 'Mã chi nhánh').id,
-                    'nhom_khach': self._find_many2one_by_code('mdm.nhom.khach', row[11] if len(row) > 11 else False, 'Nhóm khách').id,
-                    'dvcs': self.env.company.id,
-                    'ten_salesman': self._find_many2one_by_code('mdm.saleman', row[13] if len(row) > 13 else False, 'Tên Salesman').id,
-                    'vung': self._clean_value(row[14] if len(row) > 14 else False),
-                    'qlv': self._find_many2one_by_code('mdm.quan.ly.vung', row[15] if len(row) > 15 else False, 'QLV').id,
-                    'khu_vuc': self._find_many2one_by_code('mdm.khu.vuc', row[16] if len(row) > 16 else False, 'Khu vực').id,
-                    'mien_lon': self._find_many2one_by_code('mien.lon', row[17] if len(row) > 17 else False, 'Miền lớn').id,
-                    'mien_nho': self._find_many2one_by_code('mien.nho', row[18] if len(row) > 18 else False, 'Miền nhỏ').id,
+                    'ma_khach': ma_kh_ncc,
+                    'ma_dms': ma_mdm,
+                    'ten_khach': self._clean_value(row[3] if len(row) > 3 else False),
+                    'dia_chi_khach': self._clean_value(row[4] if len(row) > 4 else False),
+                    'phuong_xa_cu': self._find_many2one_by_code('phuong.xa.cu', row[5] if len(row) > 5 else False, 'Phường/xã cũ').id,
+                    'quan_huyen_cu': self._find_many2one_by_code('quan.huyen.cu', row[6] if len(row) > 6 else False, 'Quận/huyện cũ').id,
+                    'tinh_cu': self._find_many2one_by_code('tinh.cu', row[7] if len(row) > 7 else False, 'Tỉnh cũ').id,
+                    'dat_nuoc': self._find_many2one_by_code('mdm.quoc.gia', row[8] if len(row) > 8 else False, 'Quốc gia').id,
+                    'so_dien_thoai': self._clean_value(row[9] if len(row) > 9 else False),
+                    'mst': self._clean_value(row[10] if len(row) > 10 else False),
+                    'plan': self._find_many2one_by_code('mdm.plan', row[11] if len(row) > 11 else False, 'Plant').id,
+                    'ma_cn': self._find_many2one_by_code('mdm.chi.nhanh', row[12] if len(row) > 12 else False, 'CN/NPP').id,
+                    'nhom_khach': self._find_many2one_by_code('mdm.nhom.khach', row[13] if len(row) > 13 else False, 'Nhóm KH_NCC').id,
+                    'ten_salesman': self._find_many2one_by_code('mdm.saleman', row[14] if len(row) > 14 else False, 'Mã_salesman').id,
+                    'vung': self._clean_value(row[15] if len(row) > 15 else False),
+                    'qlv': self._find_many2one_by_code('mdm.quan.ly.vung', row[16] if len(row) > 16 else False, 'Quản lý vùng').id,
+                    'khu_vuc': self._find_many2one_by_code('mdm.khu.vuc', row[17] if len(row) > 17 else False, 'Khu vực').id,
+                    'mien_lon': self._find_many2one_by_code('mien.lon', row[18] if len(row) > 18 else False, 'Miền lớn').id,
+                    'mien_nho': self._find_many2one_by_code('mien.nho', row[19] if len(row) > 19 else False, 'Miền nhỏ').id,
                 }
 
-                existing = model.browse()
-                if record_id:
-                    if not str(record_id).isdigit():
-                        raise ValidationError(_('ID phải là số nguyên dương.'))
-                    existing = model.search([('id', '=', int(record_id))], limit=1)
-
+                existing = model.search([('ma_dms', '=', ma_mdm)], limit=1)
                 if existing:
-                    existing.write(vals)
+                    parent_record = existing
+                    update_vals = self._merge_non_empty_vals(existing, vals)
+                    parent_record.write(dict(update_vals, dvcs=company.id))
                     updated += 1
                 else:
-                    model.create(vals)
+                    parent_record = model.create(dict(vals, dvcs=company.id))
                     imported += 1
+
+                line_vals = {
+                    'khach_hang_id': parent_record.id,
+                    'ma_mdm': ma_mdm,
+                    'dvcs': company.id,
+                }
+                if ma_kh_ncc:
+                    line_vals['ma_dv'] = ma_kh_ncc
+                line_model.create(line_vals)
             except Exception as exc:
-                errors.append(_('Dòng %(row)s (ID: %(record_id)s): %(error)s', row=row_index, record_id=record_id or '-', error=str(exc)))
+                errors.append(_('Dòng %(row)s (Mã MDM: %(ma_mdm)s): %(error)s', row=row_index, ma_mdm=ma_mdm or '-', error=str(exc)))
 
         message = _('Import hoàn tất. Tạo mới: %(new)s, Cập nhật: %(updated)s', new=imported, updated=updated)
         if errors:

--- a/sonha_mdm/models/mdm_khach_hang_line.py
+++ b/sonha_mdm/models/mdm_khach_hang_line.py
@@ -1,0 +1,11 @@
+from odoo import fields, models
+
+
+class MDMKhachHangLine(models.Model):
+    _name = 'mdm.khach.hang.line'
+    _description = 'Bảng con MDM khách hàng'
+
+    khach_hang_id = fields.Many2one('mdm.khach.hang', string='Khách hàng', required=True, ondelete='cascade')
+    ma_mdm = fields.Char(string='Mã MDM')
+    ma_dv = fields.Char(string='Mã đơn vị')
+    dvcs = fields.Many2one('res.company', string='ĐVCS')

--- a/sonha_mdm/security/ir.model.access.csv
+++ b/sonha_mdm/security/ir.model.access.csv
@@ -42,3 +42,5 @@ access_bom_sale,bom.sale,model_bom_sale,,1,1,1,1
 access_mdm_khach_hang_import_wizard,mdm.khach.hang.import.wizard,model_mdm_khach_hang_import_wizard,,1,1,1,1
 
 access_mdm_tong_hop_line,mdm.tong.hop.line,model_mdm_tong_hop_line,,1,1,1,1
+
+access_mdm_khach_hang_line,mdm.khach.hang.line,model_mdm_khach_hang_line,,1,1,1,1

--- a/sonha_mdm/views/mdm_khach_hang_views.xml
+++ b/sonha_mdm/views/mdm_khach_hang_views.xml
@@ -48,6 +48,15 @@
                             </tree>
                         </field>
                     </page>
+                    <page string="Bảng con đơn vị">
+                        <field name="bang_con_ids">
+                            <tree editable="bottom">
+                                <field name="ma_mdm"/>
+                                <field name="ma_dv"/>
+                                <field name="dvcs"/>
+                            </tree>
+                        </field>
+                    </page>
                     <page string="Bước duyệt">
                         <field name="buoc_duyet">
                             <tree>


### PR DESCRIPTION
### Motivation
- Track per-company unit mappings for a customer by adding a child list to the customer model.
- Prevent import errors when importing files for different companies and avoid overwriting existing values with empty cells during updates.

### Description
- Added a new model `mdm.khach.hang.line` with fields `khach_hang_id`, `ma_mdm`, `ma_dv`, and `dvcs` and registered it in `models/__init__.py` and access CSV.
- Added a One2many field `bang_con_ids` on `mdm.khach.hang` and updated the customer form view to show a "Bảng con đơn vị" page with an editable tree.
- Reworked `mdm.khach.hang.import.wizard` to: validate a single company code from the file and resolve it to a `res.company`; map shifted columns to the new layout; use `_merge_non_empty_vals` to retain existing parent values when incoming cells are empty; update or create parent records with `dvcs` set to the resolved company; and create a `mdm.khach.hang.line` child line per row linking `ma_mdm` and `ma_dv`.
- Improved error messages to reference `Mã MDM` in import errors.

### Testing
- No automated tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d7596a8e88324aa355dd7c5b0729a)