### PR TITLE
Open MDM child line in form popup and add 'Mã ĐV' form view

### DIFF
--- a/sonha_mdm/models/mdm_tong_hop.py
+++ b/sonha_mdm/models/mdm_tong_hop.py
@@ -511,10 +511,12 @@ class MDMTongHop(models.Model):
 
         return {
             'type': 'ir.actions.act_window',
-            'name': 'Nhập thêm thông tin',
+            'name': 'Mã ĐV',
             'res_model': 'mdm.tong.hop.line',
-            'view_mode': 'tree',
-            'view_id': self.env.ref('sonha_mdm.view_mdm_tong_hop_line_tree').id,
-            'res_id': self.id,
-            'target': 'new'
+            'view_mode': 'form',
+            'view_id': self.env.ref('sonha_mdm.view_mdm_tong_hop_line_form').id,
+            'target': 'new',
+            'context': {
+                'default_tong_hop_id': self.id,
+            },
         }

--- a/sonha_mdm/views/view_popup_con.xml
+++ b/sonha_mdm/views/view_popup_con.xml
@@ -13,6 +13,26 @@
         </field>
     </record>
 
+
+    <record id="view_mdm_tong_hop_line_form" model="ir.ui.view">
+        <field name="name">mdm.tong.hop.line.form</field>
+        <field name="model">mdm.tong.hop.line</field>
+        <field name="arch" type="xml">
+            <form string="Mã ĐV">
+                <group>
+                    <field name="tong_hop_id" invisible="1"/>
+                    <field name="ma_mdm"/>
+                    <field name="ma_dv"/>
+                    <field name="dvcs"/>
+                </group>
+                <footer>
+                    <button string="Lưu" special="save" class="btn-primary"/>
+                    <button string="Hủy" special="cancel" class="btn-secondary"/>
+                </footer>
+            </form>
+        </field>
+    </record>
+
     <record id="action_mdm_tong_hop_line" model="ir.actions.act_window">
         <field name="name">Bảng tổng hợp con</field>
         <field name="res_model">mdm.tong.hop.line</field>


### PR DESCRIPTION
### Motivation
- Replace the editable tree popup with a focused form to enter unit-code details (`Mã ĐV`) for `mdm.tong.hop` child lines.
- Ensure the parent record is set by default when creating/editing the child line from the popup.

### Description
- Update `MDMTongHop.action_view_popup` to set the action `name` to 'Mã ĐV', switch `view_mode` to `form`, use the new view `view_mdm_tong_hop_line_form`, set `target` to `new`, and include a `context` with `default_tong_hop_id`.
- Add a new form view record `view_mdm_tong_hop_line_form` in `view_popup_con.xml` that defines a simple form with `tong_hop_id`, `ma_mdm`, `ma_dv`, and `dvcs` fields and footer buttons `Lưu` and `Hủy`.

### Testing
- No automated tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e88712f3c83249cde840496c4bf36)