### PR TITLE
Fix related field type mismatch for ket.qua.tong.hop.do_day

### DIFF
--- a/sonha_mdm/models/ket_qua_tong_hop.py
+++ b/sonha_mdm/models/ket_qua_tong_hop.py
@@ -19,7 +19,7 @@ class KetQuaTongHop(models.Model):
     nhan_hang = fields.Text(related='record.nhan_hang.ten', string="Nhãn hàng")
     chat_lieu = fields.Text(related='record.chat_lieu.ten', string="Chất liệu")
     do_bong = fields.Text(related='record.do_bong.ten', string="Độ bóng")
-    do_day = fields.Text(related='record.do_day', string="Độ dày")
+    do_day = fields.Char(related='record.do_day', string="Độ dày")
     dung_tich = fields.Text(related='record.dung_tich.ten', string="Dung tích")
     ma_tg = fields.Char(related='record.ma_tg', string="Mã TG")
 


### PR DESCRIPTION
### Motivation
- Resolve Odoo `TypeError: Type of related field ket.qua.tong.hop.do_day is inconsistent with mdm.tong.hop.do_day` by aligning the related field type with its source.

### Description
- Change `do_day` in `sonha_mdm/models/ket_qua_tong_hop.py` from `fields.Text(related='record.do_day', ...)` to `fields.Char(related='record.do_day', ...)` to match the source field `mdm.tong.hop.do_day` and committed the change.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13b55a9748832db047100a9cfd7172)