### PR TITLE
Refactor attendance/overtime time handling, local timezone conversion, and compensatory sync

### DIFF
--- a/hr_zk_attendance/models/master_data_attendance.py
+++ b/hr_zk_attendance/models/master_data_attendance.py
@@ -1,4 +1,5 @@
 from odoo import models, fields, api
+from datetime import timedelta
 
 
 class MasterDataAttendance(models.Model):
@@ -28,8 +29,8 @@ class MasterDataAttendance(models.Model):
         if rec.employee_id and rec.attendance_time:
             self.env['employee.attendance.v2'].sudo().recompute_for_employee(
                 rec.employee_id,
-                rec.attendance_time.date(),
-                rec.attendance_time.date()
+                (rec.attendance_time + timedelta(hours=7)).date() - timedelta(days=1),
+                (rec.attendance_time + timedelta(hours=7)).date() + timedelta(days=1)
             )
         return rec
 
@@ -37,17 +38,19 @@ class MasterDataAttendance(models.Model):
         res = super().write(vals)
         for rec in self:
             if rec.employee_id:
-                dt = rec.attendance_time.date()
                 self.env['employee.attendance.v2'].sudo().recompute_for_employee(
-                    rec.employee_id, dt, dt
+                    rec.employee_id,
+                    (rec.attendance_time + timedelta(hours=7)).date() - timedelta(days=1),
+                    (rec.attendance_time + timedelta(hours=7)).date() + timedelta(days=1)
                 )
         return res
 
     def unlink(self):
         for rec in self:
             if rec.employee_id and rec.attendance_time:
-                dt = rec.attendance_time.date()
                 self.env['employee.attendance.v2'].sudo().recompute_for_employee(
-                    rec.employee_id, dt, dt
+                    rec.employee_id,
+                    (rec.attendance_time + timedelta(hours=7)).date() - timedelta(days=1),
+                    (rec.attendance_time + timedelta(hours=7)).date() + timedelta(days=1)
                 )
         return super().unlink()

--- a/sonha_word_slip/models/employee_attendance_v2.py
+++ b/sonha_word_slip/models/employee_attendance_v2.py
@@ -594,9 +594,17 @@ class EmployeeAttendanceV2(models.Model):
                 order='attendance_time ASC'
             )
             attendance_values = [a['attendance_time'] for a in attendance_times if a['attendance_time']]
+            attendance_ci = [
+                value for value in attendance_values
+                if r.check_no_in and value <= r.check_no_in
+            ]
+            attendance_co = [
+                value for value in attendance_values
+                if r.check_no_out and value > r.check_no_out
+            ]
 
-            check_in = attendance_values[0] if attendance_values else None
-            check_out = attendance_values[-1] if attendance_values else None
+            check_in = attendance_ci[0] if attendance_ci else None
+            check_out = attendance_co[-1] if attendance_co else None
 
             in_outs = self.env['word.slip'].sudo().search([
                 ('from_date', '<=', r.date),
@@ -613,13 +621,15 @@ class EmployeeAttendanceV2(models.Model):
                 if in_out and in_out.time_to:
                     ci = calculate_time(in_out.time_to, r.date, datetime.combine(r.date, time(0, 0, 0)))
                     ci = ci - relativedelta(hours=7)
-                    if r.time_check_in <= ci <= r.time_check_out and (not check_in or check_in > ci):
+                    if (r.time_check_in <= ci <= r.time_check_out and r.check_no_in and ci <= r.check_no_in
+                            and (not check_in or check_in > ci)):
                         check_in = ci
 
                 if in_out and in_out.time_from:
                     co = calculate_time(in_out.time_from, r.date, datetime.combine(r.date, time(0, 0, 0)))
                     co = co - relativedelta(hours=7)
-                    if r.time_check_in <= co <= r.time_check_out and (not check_out or check_out < co):
+                    if (r.time_check_in <= co <= r.time_check_out and r.check_no_out and co > r.check_no_out
+                            and (not check_out or check_out < co)):
                         check_out = co
 
             r.check_in = check_in

--- a/sonha_word_slip/models/employee_attendance_v2.py
+++ b/sonha_word_slip/models/employee_attendance_v2.py
@@ -77,6 +77,164 @@ class EmployeeAttendanceV2(models.Model):
 
     sunday_work = fields.Float(string="Giờ làm chủ nhật", compute="_get_sunday_work", store=True)
 
+
+    LOCAL_TZ_OFFSET = timedelta(hours=7)
+    CHECK_WINDOW_HOURS = 3
+    MAX_OT_SHIFT_GAP_HOURS = 1
+
+    def _to_local_datetime(self, dt):
+        return dt + self.LOCAL_TZ_OFFSET if dt else None
+
+    def _to_utc_datetime(self, dt):
+        return dt - self.LOCAL_TZ_OFFSET if dt else None
+
+    def _float_hour_to_local_datetime(self, base_date, hour_float):
+        hour_float = hour_float or 0
+        if hour_float >= 24:
+            return datetime.combine(base_date, time(0, 0)) + timedelta(days=1)
+        hours = int(hour_float)
+        minutes = int(round((hour_float - hours) * 60))
+        if minutes >= 60:
+            hours += minutes // 60
+            minutes = minutes % 60
+        if hours >= 24:
+            return datetime.combine(base_date, time(0, 0)) + timedelta(days=1, hours=hours - 24, minutes=minutes)
+        return datetime.combine(base_date, time(hours, minutes))
+
+    def _get_shift_interval_local(self, record):
+        if not record.shift or not record.shift.start or not record.shift.end_shift or not record.date:
+            return None, None
+        start_time = self._to_local_datetime(record.shift.start).time()
+        end_time = self._to_local_datetime(record.shift.end_shift).time()
+        shift_start = datetime.combine(record.date, start_time)
+        shift_end = datetime.combine(record.date, end_time)
+        if shift_end <= shift_start:
+            shift_end += timedelta(days=1)
+        return shift_start, shift_end
+
+    def _get_shift_split_utc(self, record):
+        shift_start, shift_end = self._get_shift_interval_local(record)
+        if not shift_start or not shift_end:
+            return None
+        split_local = shift_start + (shift_end - shift_start) / 2
+        return self._to_utc_datetime(split_local)
+
+    def _get_overtime_line_interval_local(self, line):
+        if not line or not line.date:
+            return None, None
+        start = self._float_hour_to_local_datetime(line.date, line.start_time)
+        end = self._float_hour_to_local_datetime(line.date, line.end_time)
+        if end <= start:
+            end += timedelta(days=1)
+        return start, end
+
+    def _intersect_interval(self, start_a, end_a, start_b, end_b):
+        start = max(start_a, start_b)
+        end = min(end_a, end_b)
+        if end <= start:
+            return None, None
+        return start, end
+
+    def _duration_hours(self, start, end):
+        if not start or not end or end <= start:
+            return 0
+        return (end - start).total_seconds() / 3600
+
+    def _is_overtime_line_employee(self, line, employee):
+        overtime = line.overtime_id
+        return bool(
+            (overtime.employee_id and overtime.employee_id.id == employee.id) or
+            (overtime.employee_ids and employee.id in overtime.employee_ids.ids)
+        )
+
+    def _get_overtime_candidates(self, employee, date_from, date_to):
+        lines = self.env['overtime.rel'].sudo().search([
+            ('date', '>=', date_from),
+            ('date', '<=', date_to),
+            '|',
+            ('overtime_id.status', '=', 'done'),
+            ('overtime_id.status_lv2', '=', 'done'),
+        ])
+        return lines.filtered(lambda line: self._is_overtime_line_employee(line, employee))
+
+    def _get_overtime_owner_record(self, line, employee):
+        ot_start, ot_end = self._get_overtime_line_interval_local(line)
+        if not ot_start or not ot_end:
+            return self.env['employee.attendance.v2']
+        records = self.sudo().search([
+            ('employee_id', '=', employee.id),
+            ('date', '>=', line.date - timedelta(days=1)),
+            ('date', '<=', line.date + timedelta(days=1)),
+        ])
+        best_record = self.env['employee.attendance.v2']
+        best_key = None
+        for attendance in records:
+            shift_start, shift_end = self._get_shift_interval_local(attendance)
+            if not shift_start or not shift_end:
+                continue
+            overlap_start, overlap_end = self._intersect_interval(ot_start, ot_end, shift_start, shift_end)
+            overlap_hours = self._duration_hours(overlap_start, overlap_end)
+            if attendance.shift.shift_ot and overlap_hours:
+                key = (0, -overlap_hours, abs((ot_start - shift_start).total_seconds()))
+            elif not attendance.shift.shift_ot:
+                if ot_end <= shift_start:
+                    gap_hours = self._duration_hours(ot_end, shift_start)
+                    priority = 1 if gap_hours <= self.MAX_OT_SHIFT_GAP_HOURS else 2 if line.date == attendance.date else 3
+                    key = (priority, gap_hours, 0)
+                elif ot_start >= shift_end:
+                    gap_hours = self._duration_hours(shift_end, ot_start)
+                    priority = 1 if gap_hours <= self.MAX_OT_SHIFT_GAP_HOURS else 2 if ot_start.date() == shift_end.date() else 3
+                    key = (priority, gap_hours, 0)
+                else:
+                    continue
+            else:
+                continue
+            if best_key is None or key < best_key:
+                best_key = key
+                best_record = attendance
+        return best_record
+
+    def _get_owned_overtime_lines(self, record):
+        if not record.employee_id or not record.date or not record.shift:
+            return self.env['overtime.rel']
+        shift_start, shift_end = self._get_shift_interval_local(record)
+        if not shift_start or not shift_end:
+            return self.env['overtime.rel']
+        candidates = self._get_overtime_candidates(
+            record.employee_id,
+            shift_start.date() - timedelta(days=1),
+            shift_end.date() + timedelta(days=1),
+        )
+        return candidates.filtered(lambda line: self._get_overtime_owner_record(line, record.employee_id).id == record.id)
+
+    def _get_actual_overtime_hours_for_line(self, record, line):
+        if not record.check_in or not record.check_out:
+            return 0
+        ot_start, ot_end = self._get_overtime_line_interval_local(line)
+        actual_start = self._to_local_datetime(record.check_in)
+        actual_end = self._to_local_datetime(record.check_out)
+        work_start, work_end = self._intersect_interval(ot_start, ot_end, actual_start, actual_end)
+        if not work_start or not work_end:
+            return 0
+        if record.shift.shift_ot:
+            return self._duration_hours(work_start, work_end)
+
+        shift_start, shift_end = self._get_shift_interval_local(record)
+        inside_start, inside_end = self._intersect_interval(work_start, work_end, shift_start, shift_end)
+        total = self._duration_hours(work_start, work_end)
+        total -= self._duration_hours(inside_start, inside_end)
+        return max(total, 0)
+
+    def _get_actual_compensatory_hours_for_overtime(self, overtime, employee):
+        total = 0
+        for line in overtime.date:
+            if not line.date or not self._is_overtime_line_employee(line, employee):
+                continue
+            owner = self._get_overtime_owner_record(line, employee)
+            if owner:
+                total += self._get_actual_overtime_hours_for_line(owner, line) * (line.coefficient or 1)
+        return total
+
     @api.depends('employee_id', 'check_in', 'check_out', 'date')
     def _get_sunday_work(self):
         for r in self:
@@ -231,165 +389,17 @@ class EmployeeAttendanceV2(models.Model):
     @api.depends('employee_id', 'date', 'check_in', 'check_out', 'shift')
     def get_hours_reinforcement(self):
         for record in self:
+            record.over_time = 0
             record.over_time_nb = 0
+            if not record.employee_id or not record.shift:
+                continue
+
             total_overtime = 0
-            ot = self.env['register.overtime'].sudo().search([('employee_id', '=', record.employee_id.id),
-                                                              ('start_date', '<=', record.date),
-                                                              ('end_date', '>=', record.date),
-                                                              ('status', '=', 'done')])
+            for line in self._get_owned_overtime_lines(record):
+                total_overtime += self._get_actual_overtime_hours_for_line(record, line)
 
-            overtime = self.env['overtime.rel'].sudo().search([
-                '&',
-                ('date', '=', record.date),
-                '|',
-                ('overtime_id.status', '=', 'done'),
-                ('overtime_id.status_lv2', '=', 'done'),
-            ])
-            overtime = overtime.filtered(
-                lambda x: (x.overtime_id.employee_id and x.overtime_id.employee_id.id == record.employee_id.id)
-                          or (x.overtime_id.employee_ids and record.employee_id.id in x.overtime_id.employee_ids.ids))
-
-            # --- Helper: chuyển datetime -> float giờ, cộng 24 nếu ngày rơi vào hôm sau ---
-            def _dt_to_float_local(dt):
-                if not dt:
-                    return None
-                dt_local = dt + relativedelta(hours=7)
-                fl = dt_local.hour + dt_local.minute / 60
-                # Nếu datetime (sau +7h) thuộc ngày sau record.date thì coi là giờ > 24
-                if dt_local.date() > record.date:
-                    fl += 24
-                return fl
-
-            # --- Xử lý register.overtime (ot) ---
-            if ot:
-                for r in ot:
-                    # normalize start/end giờ (giữ nguyên nguồn, chỉ dùng biến tạm để tính)
-                    r_start = r.start_time
-                    r_end = r.end_time
-
-                    # Nếu end_time == 0 => hiểu là 24:00 (không bị hiểu nhầm thành 0 cùng ngày)
-                    if r_end == 0:
-                        r_end = 24
-
-                    # giữ nguyên logic cũ, chỉ dùng r_start / r_end đã normalize
-                    if r.start_date != r.end_date and r_start > r_end:
-                        if r.start_date == record.date:
-                            total_overtime += abs(24 - r_start)
-                        elif r.end_date == record.date:
-                            total_overtime += abs(r_end)
-                    else:
-                        total_overtime += abs(r_end - r_start)
-
-            # --- Xử lý overtime.rel (overtime) ---
-            if overtime:
-                for x in overtime:
-                    if not record.shift:
-                        continue
-
-                    # Giờ ca làm (float giờ)
-                    if not record.shift.shift_ot:
-                        shift_start = (record.shift.start + relativedelta(hours=7)).hour + \
-                                      (record.shift.start + relativedelta(hours=7)).minute / 60
-                        shift_end = (record.shift.end_shift + relativedelta(hours=7)).hour + \
-                                    (record.shift.end_shift + relativedelta(hours=7)).minute / 60
-
-                        # Giờ overtime đăng ký (float giờ) và normalize end==0 -> 24
-                        ot_start = x.start_time
-                        ot_end = x.end_time
-                        if ot_end == 0:
-                            ot_end = 24
-
-                        # Trường hợp overtime hoàn toàn trước ca
-                        if ot_end <= shift_start:
-                            gap = shift_start - ot_end
-                            if gap >= 1:  # Nếu cách ca >= 4 tiếng -> tính toàn bộ OT (ví dụ 0h–2h, ca 8h)
-                                total_overtime += ot_end - ot_start
-                            else:
-                                # logic chuẩn như cũ (6h–8h sát ca thì check check_in/check_out)
-                                if record.check_in:
-                                    check_in_time = _dt_to_float_local(record.check_in)
-                                    actual_start = max(ot_start, check_in_time)
-                                    actual_end = ot_end
-                                    if record.check_out:
-                                        check_out_time = _dt_to_float_local(record.check_out)
-                                        actual_end = min(actual_end, check_out_time)
-                                    if actual_end > actual_start:
-                                        total_overtime += actual_end - actual_start
-
-                        # --- Trường hợp overtime hoàn toàn sau ca ---
-                        elif shift_end <= ot_start:
-                            gap = ot_start - shift_end
-                            if gap >= 1:  # Nếu cách ca >= 4 tiếng -> tính toàn bộ OT
-                                total_overtime += ot_end - ot_start
-                            else:
-                                # logic chuẩn như cũ (OT ngay sau ca thì check check_in/check_out)
-                                if record.check_out:
-                                    check_out_time = _dt_to_float_local(record.check_out)
-                                    actual_start = ot_start
-                                    actual_end = min(ot_end, check_out_time)
-                                    if record.check_in:
-                                        check_in_time = _dt_to_float_local(record.check_in)
-                                        actual_start = max(actual_start, check_in_time)
-                                    if actual_end > actual_start:
-                                        total_overtime += actual_end - actual_start
-
-                        # Trường hợp overtime nằm trong giờ ca (hoặc chồng 1 phần ca)
-                        else:
-                            # phần trước ca (nếu có)
-                            if ot_start < shift_start:
-                                actual_start = ot_start
-                                if record.check_in:
-                                    check_in_time = _dt_to_float_local(record.check_in)
-                                    actual_start = max(actual_start, check_in_time)
-                                actual_end = min(ot_end, shift_start)
-                                if record.check_out:
-                                    check_out_time = _dt_to_float_local(record.check_out)
-                                    actual_end = min(actual_end, check_out_time)
-                                if actual_end > actual_start:
-                                    total_overtime += actual_end - actual_start
-
-                            # phần sau ca (nếu có)
-                            if ot_end > shift_end:
-                                actual_start = max(ot_start, shift_end)
-                                if record.check_in:
-                                    check_in_time = _dt_to_float_local(record.check_in)
-                                    actual_start = max(actual_start, check_in_time)
-                                actual_end = ot_end
-                                if record.check_out:
-                                    check_out_time = _dt_to_float_local(record.check_out)
-                                    actual_end = min(actual_end, check_out_time)
-                                if actual_end > actual_start:
-                                    total_overtime += actual_end - actual_start
-
-                            # phần trong ca
-                            inside_start = max(ot_start, shift_start)
-                            inside_end = min(ot_end, shift_end)
-                            if record.check_in:
-                                check_in_time = _dt_to_float_local(record.check_in)
-                                inside_start = max(inside_start, check_in_time)
-                            if record.check_out:
-                                check_out_time = _dt_to_float_local(record.check_out)
-                                inside_end = min(inside_end, check_out_time)
-                            if inside_end > inside_start:
-                                total_overtime += inside_end - inside_start
-
-                    else:
-                        # Nếu shift_ot = True → tính thẳng theo khoảng OT nhưng vẫn cắt theo check_in/check_out
-                        if record.check_in and record.check_out:
-                            check_in_time = _dt_to_float_local(record.check_in)
-                            check_out_time = _dt_to_float_local(record.check_out)
-                            actual_start = max(x.start_time, check_in_time)
-                            # normalize x.end_time == 0 case
-                            ot_end = x.end_time
-                            if ot_end == 0:
-                                ot_end = 24
-                            actual_end = min(ot_end, check_out_time)
-                            if actual_end > actual_start:
-                                total_overtime += actual_end - actual_start
-
-            # --- Gán kết quả như cũ ---
             if record.shift.type_ot == 'nb':
-                record.over_time_nb = total_overtime * record.shift.coefficient
+                record.over_time_nb = total_overtime * (record.shift.coefficient or 1)
                 record.over_time = 0
             else:
                 if record.weekday == '6' and record.employee_id.company_id.id == 16:
@@ -496,64 +506,35 @@ class EmployeeAttendanceV2(models.Model):
                 r.shift = r.employee_id.shift.id
 
     # Lấy thông tin giờ phải check-in và giờ check-out của nhân viên
-    @api.depends('shift')
+    @api.depends('shift', 'employee_id', 'date')
     def _get_time_in_out(self):
         for r in self:
-            # Nếu không có shift, gán giá trị mặc định và bỏ qua
-            if not r.shift or not r.shift.start or not r.shift.end_shift:
-                r.time_check_in = None
-                r.time_check_out = None
+            r.time_check_in = None
+            r.time_check_out = None
+            if not r.shift or not r.shift.start or not r.shift.end_shift or not r.date:
                 continue
 
-            # Tính toán các giá trị thời gian cơ bản
-            time_ci = (r.shift.start + timedelta(hours=7)).time()
-            time_co = (r.shift.end_shift + timedelta(hours=7)).time()
-            date = r.date
-            check_time_ci = datetime.combine(date, time_ci)
-            check_time_co = datetime.combine(date, time_co)
+            shift_start, shift_end = self._get_shift_interval_local(r)
+            if not shift_start or not shift_end:
+                continue
 
-            # Tính thời gian check-in
-            time_check_in = check_time_ci - timedelta(hours=7, minutes=420)
+            window_start = shift_start - timedelta(hours=self.CHECK_WINDOW_HOURS)
+            window_end = shift_end + timedelta(hours=self.CHECK_WINDOW_HOURS)
 
-            # Tính thời gian check-out
-            time_check_out = check_time_co + timedelta(hours=-7, minutes=420)
+            for line in self._get_owned_overtime_lines(r):
+                ot_start, ot_end = self._get_overtime_line_interval_local(line)
+                if not ot_start or not ot_end:
+                    continue
+                if ot_end <= shift_start:
+                    window_start = min(window_start, ot_start - timedelta(hours=self.CHECK_WINDOW_HOURS))
+                elif ot_start >= shift_end:
+                    window_end = max(window_end, ot_end + timedelta(hours=self.CHECK_WINDOW_HOURS))
+                elif r.shift.shift_ot:
+                    window_start = min(window_start, ot_start - timedelta(hours=self.CHECK_WINDOW_HOURS))
+                    window_end = max(window_end, ot_end + timedelta(hours=self.CHECK_WINDOW_HOURS))
 
-            # Xử lý trường hợp night shift
-            if r.shift.night:
-                # Nếu ngày của check-in và check-out giống nhau, điều chỉnh thời gian check-out qua ngày hôm sau
-                if (time_check_in + timedelta(hours=7)).date() == (time_check_out + timedelta(hours=7)).date():
-                    time_check_out += timedelta(days=1)
-            overtime = self.env['register.overtime'].sudo().search([('employee_id', '=', r.employee_id.id),
-                                                                    ('start_date', '<=', r.date),
-                                                                    ('end_date', '>=', r.date)])
-            overtime_update = self.env['overtime.rel'].sudo().search([('date', '=', r.date),
-                                                                      ('overtime_id.status', '=', 'done')])
-            overtime_update = overtime_update.filtered(
-                lambda x: (x.overtime_id.employee_id and x.overtime_id.employee_id.id == r.employee_id.id)
-                          or (x.overtime_id.employee_ids and r.employee_id.id in x.overtime_id.employee_ids.ids))
-            if overtime:
-                for ot in overtime:
-                    start = int(ot.start_time)
-                    end = int(ot.end_time)
-                    if end == r.shift.start.hour + 7:
-                        time_check_in = time_check_in - timedelta(hours=end - start)
-                    if start == r.shift.end_shift.hour + 7:
-                        time_check_out = time_check_out + timedelta(hours=end - start)
-
-            if overtime_update:
-                for ot_update in overtime_update:
-                    start = int(ot_update.start_time)
-                    end = int(ot_update.end_time)
-                    if end == r.shift.start.hour + 7:
-                        time_check_in = time_check_in - timedelta(hours=end - start)
-                    if start == r.shift.end_shift.hour + 7:
-                        time_check_out = time_check_out + timedelta(hours=end - start)
-                    if start != r.shift.end_shift.hour + 7:
-                        time_check_out = time_check_out + timedelta(hours=end - start)
-
-            # Gán kết quả
-            r.time_check_in = time_check_in
-            r.time_check_out = time_check_out
+            r.time_check_in = self._to_utc_datetime(window_start)
+            r.time_check_out = self._to_utc_datetime(window_end)
 
     # Lấy ra thông tin số giờ cần có mặt theo ca
     @api.depends('shift')
@@ -577,18 +558,10 @@ class EmployeeAttendanceV2(models.Model):
         for r in self:
             r.check_no_in = None
             r.check_no_out = None
-            if r.shift and r.shift.start and r.shift.end_shift:
-                time_ci = (r.shift.start + timedelta(hours=7)).time()
-                time_co = (r.shift.end_shift + timedelta(hours=7)).time()
-                date = r.date
-                no_in_check = datetime.combine(date, time_ci)
-                no_out_check = datetime.combine(date, time_co)
-
-                # Tính thời gian check-in
-                r.check_no_in = no_in_check + timedelta(hours=2, minutes=-300)
-
-                # Tính thời gian check-out
-                r.check_no_out = no_out_check - timedelta(hours=9)
+            split_utc = self._get_shift_split_utc(r)
+            if split_utc:
+                r.check_no_in = split_utc
+                r.check_no_out = split_utc
 
     # Lấy thông tin check-in và check-out của nhân viên
     @api.depends('employee_id', 'time_check_in', 'time_check_out', 'check_no_in', 'check_no_out')
@@ -598,18 +571,21 @@ class EmployeeAttendanceV2(models.Model):
                 raise ValueError(f"Invalid time value: {input_time}")
 
             hour = int(input_time)
-            minute = int((input_time % 1) * 60)
+            minute = int(round((input_time % 1) * 60))
+            if minute >= 60:
+                hour += minute // 60
+                minute = minute % 60
+            if hour >= 24:
+                return datetime.combine(date, time(0, 0, 0)) + timedelta(days=1, hours=hour - 24, minutes=minute)
             if 0 <= hour < 24:
                 return datetime.combine(date, time(hour, minute, 0))
-            else:
-                return default_time
+            return default_time
 
         for r in self:
             r.check_in, r.check_out = None, None
             if not r.time_check_in or not r.time_check_out or not r.employee_id:
                 continue
 
-            # Lấy attendance_times từ cơ sở dữ liệu
             attendance_times = self.env['master.data.attendance'].sudo().search_read(
                 [('attendance_time', '>=', r.time_check_in),
                  ('attendance_time', '<=', r.time_check_out),
@@ -617,20 +593,11 @@ class EmployeeAttendanceV2(models.Model):
                 ['attendance_time'],
                 order='attendance_time ASC'
             )
+            attendance_values = [a['attendance_time'] for a in attendance_times if a['attendance_time']]
 
-            # Tách dữ liệu check_in và check_out
-            attendance_ci = [a['attendance_time'] for a in attendance_times if
-                             a['attendance_time'] and r.check_no_in and a['attendance_time'] <= r.check_no_in]
-            attendance_co = [a['attendance_time'] for a in attendance_times if
-                             a['attendance_time'] and r.check_no_out and a['attendance_time'] >= r.check_no_out]
+            check_in = attendance_values[0] if attendance_values else None
+            check_out = attendance_values[-1] if attendance_values else None
 
-            check_in = attendance_ci[0] if attendance_ci else None
-            check_out = attendance_co[-1] if attendance_co else None
-
-            r.check_in = check_in
-            r.check_out = check_out
-
-            # Xử lý in_outs
             in_outs = self.env['word.slip'].sudo().search([
                 ('from_date', '<=', r.date),
                 ('to_date', '>=', r.date),
@@ -646,20 +613,17 @@ class EmployeeAttendanceV2(models.Model):
                 if in_out and in_out.time_to:
                     ci = calculate_time(in_out.time_to, r.date, datetime.combine(r.date, time(0, 0, 0)))
                     ci = ci - relativedelta(hours=7)
-
-                    if not check_in and r.time_check_in and r.check_no_in and r.time_check_in <= ci <= r.check_no_in:
-                        r.check_in = ci
-                    elif check_in and check_in > ci and r.time_check_in and r.check_no_in and r.time_check_in <= ci <= r.check_no_in:
-                        r.check_in = ci
+                    if r.time_check_in <= ci <= r.time_check_out and (not check_in or check_in > ci):
+                        check_in = ci
 
                 if in_out and in_out.time_from:
                     co = calculate_time(in_out.time_from, r.date, datetime.combine(r.date, time(0, 0, 0)))
                     co = co - relativedelta(hours=7)
+                    if r.time_check_in <= co <= r.time_check_out and (not check_out or check_out < co):
+                        check_out = co
 
-                    if not check_out and r.check_no_out and r.time_check_out and r.check_no_out <= co <= r.time_check_out:
-                        r.check_out = co
-                    elif check_out and check_out < co and r.check_no_out and r.time_check_out and r.check_no_out <= co <= r.time_check_out:
-                        r.check_out = co
+            r.check_in = check_in
+            r.check_out = check_out
 
     # Lấy thông tin xem nhân viên có check-in hay check-out hay không
     @api.depends('shift', 'check_out', 'check_in')
@@ -682,37 +646,24 @@ class EmployeeAttendanceV2(models.Model):
     @api.depends('check_out', 'check_in', 'employee_id')
     def _get_minute_late_early(self):
         for r in self:
-            # Khởi tạo giá trị mặc định
             r.minutes_late, r.minutes_early = 0, 0
-
             if not r.shift or not r.shift.start or not r.shift.end_shift:
                 continue
 
-            # Tính thời gian bắt đầu và kết thúc ca làm việc
-            shift_start_time = datetime.combine(r.date, r.shift.start.time()) + timedelta(hours=7)
-            shift_end_time = datetime.combine(r.date, r.shift.end_shift.time()) + timedelta(hours=7)
+            shift_start_time, shift_end_time = self._get_shift_interval_local(r)
+            if not shift_start_time or not shift_end_time:
+                continue
 
             if r.check_in:
-                check_in_time = r.check_in + timedelta(hours=7)
-                if check_in_time.time() > shift_start_time.time():
-                    minute_late = (check_in_time - datetime.combine(check_in_time.date(),
-                                                                    shift_start_time.time())).total_seconds() / 60
-                    r.minutes_late = int(minute_late)
+                check_in_time = self._to_local_datetime(r.check_in)
+                if check_in_time > shift_start_time:
+                    r.minutes_late = int((check_in_time - shift_start_time).total_seconds() / 60)
 
             if r.check_out:
-                check_out_time = r.check_out + timedelta(hours=7)
+                check_out_time = self._to_local_datetime(r.check_out)
                 if check_out_time < shift_end_time:
-                    hour = shift_end_time.time().hour
-                    minute = shift_end_time.time().minute
-                    second = shift_end_time.time().second
-                    if hour == 0:
-                        shift_end_in_hours = 24.0
-                    else:
-                        shift_end_in_hours = hour + minute / 60 + second / 3600
-                    checkout_hour = check_out_time.hour + check_out_time.minute / 60 + check_out_time.second / 3600
+                    r.minutes_early = int((shift_end_time - check_out_time).total_seconds() / 60)
 
-                    minute_early = (shift_end_in_hours - checkout_hour) * 60
-                    r.minutes_early = int(minute_early)
             if r.leave > 0 or r.compensatory > 0 or r.vacation > 0:
                 r.minutes_early = 0
                 r.minutes_late = 0
@@ -724,8 +675,6 @@ class EmployeeAttendanceV2(models.Model):
                     r.shift.is_office_hour and (weekday == 6 or (weekday == 5 and week_number % 2 == 1))):
                 r.minutes_early = 0
                 r.minutes_late = 0
-            else:
-                pass
 
     # Lấy thông tin ngày công của nhân viên
     @api.depends('check_in', 'check_out', 'shift')
@@ -985,11 +934,27 @@ class EmployeeAttendanceV2(models.Model):
                 # hoặc gọi recompute cụ thể
                 recs._get_shift_employee()
                 recs._get_time_off()
-                recs.get_hours_reinforcement()
                 recs._get_time_in_out()
+                recs._check_no_in_out()
                 recs._get_check_in_out()
+                recs.get_hours_reinforcement()
+                recs._get_minute_late_early()
                 recs._get_work_day()
                 recs.get_department()
+
+        overtime_domain = []
+        if date_from:
+            overtime_domain.append(('date', '>=', fields.Date.to_date(date_from) - timedelta(days=1)))
+        if date_to:
+            overtime_domain.append(('date', '<=', fields.Date.to_date(date_to) + timedelta(days=1)))
+        if overtime_domain:
+            overtime_records = self.env['overtime.rel'].sudo().search(overtime_domain).mapped('overtime_id')
+            overtime_records = overtime_records.filtered(
+                lambda overtime: (overtime.employee_id and overtime.employee_id.id == emp_id) or
+                                 (overtime.employee_ids and emp_id in overtime.employee_ids.ids)
+            )
+            for overtime in overtime_records:
+                overtime._sync_actual_compensatory_for_record(overtime)
         return True
 
     def action_export_excel(self, ids):

--- a/sonha_word_slip/models/overtime_rel.py
+++ b/sonha_word_slip/models/overtime_rel.py
@@ -16,81 +16,24 @@ class OvertimeRel(models.Model):
 
     @api.constrains("date", "start_time", "end_time", "overtime_id")
     def validate_overtime(self):
+        Attendance = self.env['employee.attendance.v2'].sudo()
         for record in self:
             if record.end_time < record.start_time:
                 raise ValidationError("Thời gian kết thúc không được bé hơn thời gian bắt đầu!")
-            if record.start_time >= 24:
-                start_hours = 0
-            else:
-                start_hours = record.start_time
-
-            if record.end_time >= 24:
-                end_hours = 0
-            else:
-                end_hours = record.end_time
-
-            hours_start = int(start_hours)
-            minutes_start = int(round((start_hours - hours_start) * 60))
-            time_start = time(hour=hours_start, minute=minutes_start)
-            hours_end = int(end_hours)
-            minutes_end = int(round((end_hours - hours_end) * 60))
-            time_end = time(hour=hours_end, minute=minutes_end)
             list_employee = [
                 record.overtime_id.employee_id.id] if record.overtime_id.employee_id else record.overtime_id.employee_ids.ids
-            for employee in list_employee:
-                data = self.env['employee.attendance'].sudo().search([
-                    ('date', '=', record.date),
-                    ('employee_id', '=', employee)])
-                check_in_out = self.env['master.data.attendance'].sudo().search([
-                    ('employee_id', '=', employee)])
-                check_in_out = check_in_out.filtered(lambda x: (x.attendance_time + relativedelta(hours=7)).date() == record.date)
-                not_check_in_out = data.filtered(lambda x: (x.check_in and x.check_in.date() == record.date) or (x.check_out and x.check_out.date() == record.date))
-                shift = data.shift
-                if not shift:
+            ot_start, ot_end = Attendance._get_overtime_line_interval_local(record)
+            for employee_id in list_employee:
+                employee = self.env['hr.employee'].sudo().browse(employee_id)
+                owner = Attendance._get_overtime_owner_record(record, employee)
+                if not owner or not owner.shift:
                     raise ValidationError("Không thể tạo bản ghi khi bạn chưa có ca làm việc")
-                if not check_in_out and not not_check_in_out:
-                    raise ValidationError("Không thể tạo bản ghi do không có dữ liệu check_in check_out!")
-                start_shift = (shift.start + relativedelta(hours=7)).time()
-                start_noon_shift = shift.from_rest if shift.from_rest else False
-                if start_noon_shift:
-                    start_noon_shift = (shift.from_rest + relativedelta(hours=7)).time()
-                end_shift = (shift.end_shift + relativedelta(hours=7)).time()
-                end_noon_shift = shift.to_rest if shift.to_rest else False
-                if end_noon_shift:
-                    end_noon_shift = (shift.to_rest + relativedelta(hours=7)).time()
-
-                if not shift.shift_ot:
-                    def is_overlap(start1, end1, start2, end2):
-                        return start1 < end2 and end1 > start2
-
-                    if start_noon_shift and end_noon_shift:
-                        if (
-                                is_overlap(time_start, time_end, start_shift, start_noon_shift) or
-                                is_overlap(time_start, time_end, end_noon_shift, end_shift)
-                        ):
-                            raise ValidationError(
-                                "Khoảng thời gian bạn đăng ký đã nằm trong thời gian làm việc của ca!")
-                    else:
-                        # Không có nghỉ trưa, ca làm liền mạch
-                        if is_overlap(time_start, time_end, start_shift, end_shift):
-                            raise ValidationError(
-                                "Khoảng thời gian bạn đăng ký đã nằm trong thời gian làm việc của ca!")
-                # else:
-                #     def is_inside(start1, end1, start2, end2):
-                #         return start1 >= start2 and end1 <= end2
-                #
-                #     if start_noon_shift and end_noon_shift:
-                #         # Có phân tách giữa ca sáng và chiều (loại trừ giờ nghỉ trưa)
-                #         valid = (
-                #                 is_inside(time_start, time_end, start_shift, start_noon_shift) or
-                #                 is_inside(time_start, time_end, end_noon_shift, end_shift)
-                #         )
-                #     else:
-                #         # Không có giờ nghỉ trưa → dùng mốc 08:00 – 17:00
-                #         valid = is_inside(time_start, time_end, start_shift, end_shift)
-                #
-                #     if not valid:
-                #         raise ValidationError("Chỉ được phép đăng ký trong khoảng thời gian của ca")
+                if not owner.shift.shift_ot:
+                    shift_start, shift_end = Attendance._get_shift_interval_local(owner)
+                    overlap_start, overlap_end = Attendance._intersect_interval(ot_start, ot_end, shift_start, shift_end)
+                    if overlap_start and overlap_end:
+                        raise ValidationError(
+                            "Khoảng thời gian bạn đăng ký đã nằm trong thời gian làm việc của ca!")
 
     def unlink(self):
         for r in self:

--- a/sonha_word_slip/models/register_overtime_update.py
+++ b/sonha_word_slip/models/register_overtime_update.py
@@ -51,6 +51,7 @@ class RegisterOvertimeUpdate(models.Model):
     employee_security = fields.Many2one('hr.employee', compute='get_employee_security')
     all_times = fields.Text(string="Thời gian", compute="_compute_all_times", store=True)
     record_url = fields.Char(string="Record URL", compute="_compute_record_url")
+    actual_compensatory_hours = fields.Text(string="Giờ nghỉ bù thực tế", default="{}")
 
     @api.constrains('date')
     def _check_overtime_conflict(self):
@@ -62,9 +63,9 @@ class RegisterOvertimeUpdate(models.Model):
                     raise ValidationError("Không được để trống lý do")
                 if not rec.date:
                     raise ValidationError("Không được để trống ngày")
-                if not rec.start_time:
+                if rec.start_time is False:
                     raise ValidationError("Không được để trống thời gian bắt đầu")
-                if not rec.end_time:
+                if rec.end_time is False:
                     raise ValidationError("Không được để trống thời gian kết thúc")
 
     @api.depends('employee_id', 'employee_ids')
@@ -275,7 +276,7 @@ class RegisterOvertimeUpdate(models.Model):
                         ON rel.employee_overtime_rel = rov.id
                         AND rov.type != 'one'
                     WHERE ovr.date IS NOT NULL
-                    AND ovr.start_time > 0
+                    AND ovr.start_time >= 0
                     AND ovr.end_time > 0;
                 """, {'overtime_id': overtime_id.id})
 
@@ -327,7 +328,7 @@ class RegisterOvertimeUpdate(models.Model):
                         ON rel.employee_overtime_rel = rov.id
                         AND rov.type != 'one'
                     WHERE ovr.date IS NOT NULL
-                    AND ovr.start_time > 0
+                    AND ovr.start_time >= 0
                     AND ovr.end_time > 0;
                 """, {'overtime_id': overtime_id.id})
 
@@ -335,6 +336,9 @@ class RegisterOvertimeUpdate(models.Model):
         res = super(RegisterOvertimeUpdate, self).write(vals)
         for rec in self:
             rec.explode_to_overtime_write(rec)
+            if not self.env.context.get('skip_overtime_actual_sync') and (rec.status == 'done' or rec.status_lv2 == 'done'):
+                rec._recompute_overtime_for_record(rec)
+                rec._sync_actual_compensatory_for_record(rec)
         return res
 
     @api.onchange('employee_id', 'employee_ids', 'status_lv2', 'type_overtime')
@@ -375,39 +379,20 @@ class RegisterOvertimeUpdate(models.Model):
                 prev_status = r.status
                 r.status_lv2 = 'done'
                 r.status = 'done'
-                over_time = 0
-                for ot in r.date:
-                    time_ot = (ot.end_time - ot.start_time) * ot.coefficient
-                    over_time += time_ot
-                list_employee = r.employee_ids or [r.employee_id]
-                for employee in list_employee:
-                    if employee.department_id.over_time == 'date':
-                        employee.total_compensatory += over_time
-                    else:
-                        pass
-                # gọi recompute chỉ khi chuyển sang done (hoặc luôn vì ta vừa cộng bù)
-                # Nếu trước đó chưa phải done thì apply recompute
                 if prev_status != 'done':
                     self._recompute_overtime_for_record(r)
+                self._sync_actual_compensatory_for_record(r)
             else:
                 raise ValidationError("Bạn không có quyền thực hiện hành động này")
 
     def action_back_status(self):
         for r in self:
             prev_status = r.status
-            over_time = 0
-            for ot in r.date:
-                time_ot = (ot.end_time - ot.start_time) * ot.coefficient
-                over_time += time_ot
             list_employee = r.employee_ids or [r.employee_id]
             if list_employee[-1].parent_id.id == self.env.user.employee_id.id or self.env.user.has_group('sonha_employee.group_manager_employee') or self.env.user.has_group("sonha_word_slip.group_approve_work") or list_employee[-1].employee_approval.id == self.env.user.employee_id.id:
                 r.status = 'draft'
                 r.status_lv2 = 'draft'
-                for employee in list_employee:
-                    if employee.department_id.over_time == 'date':
-                        employee.total_compensatory -= over_time
-                    else:
-                        pass
+                self._sync_actual_compensatory_for_record(r)
                 if prev_status == 'done':
                     self._recompute_overtime_for_record(r)
             else:
@@ -416,33 +401,20 @@ class RegisterOvertimeUpdate(models.Model):
     def action_confirm(self):
         for r in self:
             prev_status = r.status
-            over_time = 0
-            for ot in r.date:
-                time_ot = (ot.end_time - ot.start_time) * ot.coefficient
-                over_time += time_ot
             if r.type == 'one':
                 if r.department_id.manager_id.user_id.id == self.env.user.id or self.env.user.id == 1738 or r.employee_id.parent_id.user_id.id == self.env.user.id or self.env.user.has_group("sonha_word_slip.group_approve_work"):
                     r.status = 'done'
-                    if r.employee_id.department_id.over_time == 'date':
-                        r.employee_id.total_compensatory += over_time
-                    else:
-                        pass
                 else:
                     raise ValidationError("Bạn không có quyền thực hiện hành động này")
             else:
                 if r.department_id.manager_id.user_id.id == self.env.user.id or self.env.user.id == 1738 or r.employee_ids[-1].parent_id.user_id.id == self.env.user.id or self.env.user.has_group("sonha_word_slip.group_approve_work"):
                     r.status = 'done'
-                    for employee in r.employee_ids:
-                        if employee.department_id.over_time == 'date':
-                            employee.total_compensatory += over_time
-                        else:
-                            pass
                 else:
                     raise ValidationError("Bạn không có quyền thực hiện hành động này")
             self.action_noti_user(r)
-            # nếu chuyển sang done từ trạng thái khác -> recompute
             if prev_status != 'done':
                 self._recompute_overtime_for_record(r)
+            self._sync_actual_compensatory_for_record(r)
 
     def action_noti_user(self, record):
         user_id = self.env['res.users'].sudo().search([('id', '=', record.create_uid.id)])
@@ -462,6 +434,8 @@ class RegisterOvertimeUpdate(models.Model):
         for r in self:
             prev_status = r.status
             r.status = 'draft'
+            r.status_lv2 = 'draft'
+            self._sync_actual_compensatory_for_record(r)
             # nếu trước đó là done -> undo -> recompute
             if prev_status == 'done':
                 self._recompute_overtime_for_record(r)
@@ -473,6 +447,44 @@ class RegisterOvertimeUpdate(models.Model):
             self.env['rel.lam.them'].sudo().search([('key_form', '=', r.id)]).unlink()
         return super(RegisterOvertimeUpdate, self).unlink()
 
+    def _get_actual_compensatory_map(self):
+        self.ensure_one()
+        if not self.actual_compensatory_hours:
+            return {}
+        try:
+            data = json.loads(self.actual_compensatory_hours)
+        except Exception:
+            return {}
+        return data if isinstance(data, dict) else {}
+
+    def _sync_actual_compensatory_for_record(self, rec):
+        employees = rec.employee_ids or (rec.employee_id and [rec.employee_id]) or []
+        old_values = rec._get_actual_compensatory_map()
+        new_values = {}
+        Attendance = self.env['employee.attendance.v2'].sudo()
+        is_done = rec.status == 'done' or rec.status_lv2 == 'done'
+
+        for employee in employees:
+            old_amount = float(old_values.get(str(employee.id), 0) or 0)
+            new_amount = 0
+            if is_done and employee.department_id.over_time == 'date':
+                new_amount = Attendance._get_actual_compensatory_hours_for_overtime(rec, employee)
+            delta = new_amount - old_amount
+            if delta:
+                employee.sudo().total_compensatory += delta
+            if new_amount:
+                new_values[str(employee.id)] = new_amount
+
+        removed_employee_ids = set(old_values.keys()) - {str(emp.id) for emp in employees}
+        for employee_id in removed_employee_ids:
+            old_amount = float(old_values.get(employee_id, 0) or 0)
+            if old_amount:
+                employee = self.env['hr.employee'].sudo().browse(int(employee_id))
+                if employee.exists():
+                    employee.total_compensatory -= old_amount
+
+        rec.with_context(skip_overtime_actual_sync=True).write({'actual_compensatory_hours': json.dumps(new_values)})
+
     def _recompute_overtime_for_record(self, rec):
         employees = rec.employee_ids or (rec.employee_id and [rec.employee_id]) or []
         if not employees:
@@ -482,8 +494,8 @@ class RegisterOvertimeUpdate(models.Model):
             if not line.date:
                 continue
 
-            date_from = line.date
-            date_to = line.date
+            date_from = line.date - timedelta(days=1)
+            date_to = line.date + timedelta(days=1)
 
             for emp in employees:
                 self.env['employee.attendance.v2'].sudo().recompute_for_employee(


### PR DESCRIPTION
### Motivation
- Unify and correct time calculations across attendance and overtime features by accounting for local timezone (+7h) and multi-day intervals. 
- Improve overtime ownership and actual compensatory calculation so compensatory balances are accurate when overtime records change. 
- Replace ad-hoc datetime arithmetic with reusable helpers to reduce bugs in check-in/out, overtime allocation, and recompute windows.

### Description
- Introduced timezone-aware helpers and utilities in `employee.attendance.v2` (`LOCAL_TZ_OFFSET`, `_to_local_datetime`, `_to_utc_datetime`, `_get_shift_interval_local`, `_get_overtime_line_interval_local`, `_intersect_interval`, `_duration_hours`, etc.) and rewrote overtime ownership and actual-hours logic via `_get_overtime_candidates`, `_get_overtime_owner_record`, `_get_owned_overtime_lines`, and `_get_actual_overtime_hours_for_line`.
- Reworked check window, check-in/check-out detection and minute/early-late calculations to use the new helpers and local conversions, and simplified `get_hours_reinforcement` to sum actual overtime from owned lines.
- Adjusted `master.data.attendance` to call `employee.attendance.v2.recompute_for_employee` with a +/-1 day window based on local date of `attendance_time` to ensure related records are recomputed correctly.
- Updated `overtime.rel` validation to use the new attendance helpers and to check overlap with the owner record's shift instead of legacy ad-hoc checks.
- Extended `register.overtime.update` to persist `actual_compensatory_hours`, sync compensatory balances via `_sync_actual_compensatory_for_record`, invoke recompute/sync on status changes, and expand recompute ranges to +/-1 day; added JSON map helpers and safe update logic to avoid double adjustments using context flag `skip_overtime_actual_sync`.
- Minor fixes: more robust float-to-time rounding, safe start_time boundary in SQL (`>= 0`), dependency adjustments for computed fields, and reordered recompute calls to ensure fields are consistent.

### Testing
- No automated test suite was executed as part of this rollout.  Manual inspection and local runs were used to validate logic changes in time conversion and recompute flows.  Automated tests should be added or run to fully verify edge cases around multi-day shifts and overtime allocation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a18f33c1f0483229da405ede30fd9ed)