### PR TITLE
Normalize MDM import many2one lookup codes

### DIFF
--- a/sonha_mdm/models/mdm_khach_hang_import_wizard.py
+++ b/sonha_mdm/models/mdm_khach_hang_import_wizard.py
@@ -30,7 +30,8 @@ class MDMKhachHangImportWizard(models.TransientModel):
         if not code:
             return self.env[model_name].browse()
 
-        record = self.env[model_name].search([('ma', '=', code)], limit=1)
+        code = code.lower()
+        record = self.env[model_name].search([('ma', '=ilike', code)], limit=1)
         if record:
             return record
 

--- a/sonha_mdm/models/mdm_tong_hop_import_wizard.py
+++ b/sonha_mdm/models/mdm_tong_hop_import_wizard.py
@@ -29,7 +29,9 @@ class MDMTongHopImportWizard(models.TransientModel):
         code = self._clean_value(code)
         if not code:
             return self.env[model_name].browse()
-        record = self.env[model_name].search([('ma', '=', code)], limit=1)
+
+        code = code.lower()
+        record = self.env[model_name].search([('ma', '=ilike', code)], limit=1)
         if record:
             return record
         raise ValidationError(_('Không tìm thấy dữ liệu ở field %(field)s với mã "%(code)s".', field=field_label, code=code))


### PR DESCRIPTION
### Motivation
- Excel import codes for many2one fields can come in mixed case and exact `=` lookups on `ma` miss matches when casing differs. 
- Normalize lookup input and use case-insensitive matching so imports find related records regardless of letter case.

### Description
- Update `_find_many2one_by_code` in `sonha_mdm/models/mdm_tong_hop_import_wizard.py` to convert the cleaned code to lowercase and search with `('ma', '=ilike', code)`.
- Apply the same change to `_find_many2one_by_code` in `sonha_mdm/models/mdm_khach_hang_import_wizard.py` so customer imports behave consistently.
- No other import logic or validations were changed.

### Testing
- Ran a syntax/AST sanity check with `python3 - <<'PY' ... ast.parse(...) ... PY` for both modified files and it succeeded.
- Compiled both files with `python3 -m py_compile` and `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile` and they passed without errors.
- Ran `git diff --check` to ensure there are no whitespace/patch issues and it reported no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1942022534832da483bce617db8d6b)