### PR TITLE
Tối ưu hiệu năng import MDM hàng hóa (Excel)

### DIFF
--- a/sonha_mdm/models/bom_sale.py
+++ b/sonha_mdm/models/bom_sale.py
@@ -5,5 +5,5 @@ class BomSale(models.Model):
     _name = 'bom.sale'
     _rec_name = 'ten'
 
-    ma = fields.Char("Mã", store=True)
+    ma = fields.Char("Mã", store=True, index=True)
     ten = fields.Char("Tên", store=True)

--- a/sonha_mdm/models/mdm_chat_lieu.py
+++ b/sonha_mdm/models/mdm_chat_lieu.py
@@ -5,5 +5,5 @@ class MDMChatLieu(models.Model):
     _name = 'mdm.chat.lieu'
     _rec_name = 'ten'
 
-    ma = fields.Char("Mã", store=True)
+    ma = fields.Char("Mã", store=True, index=True)
     ten = fields.Text("Tên", store=True)

--- a/sonha_mdm/models/mdm_chung_loai1.py
+++ b/sonha_mdm/models/mdm_chung_loai1.py
@@ -5,5 +5,5 @@ class MDMChungLoai1(models.Model):
     _name = 'mdm.chung.loai1'
     _rec_name = 'ten'
 
-    ma = fields.Char("Mã", store=True)
+    ma = fields.Char("Mã", store=True, index=True)
     ten = fields.Text("Tên", store=True)

--- a/sonha_mdm/models/mdm_chung_loai2.py
+++ b/sonha_mdm/models/mdm_chung_loai2.py
@@ -5,7 +5,7 @@ class MDMChungLoai2(models.Model):
     _name = 'mdm.chung.loai2'
     _rec_name = 'ten'
 
-    ma = fields.Char("Mã", store=True)
+    ma = fields.Char("Mã", store=True, index=True)
     ten = fields.Text("Tên", store=True)
     key = fields.Many2one('mdm.chung.loai1', string="Key mapping")
     key_linh_vuc = fields.Integer("Key lĩnh vực")

--- a/sonha_mdm/models/mdm_do_bong.py
+++ b/sonha_mdm/models/mdm_do_bong.py
@@ -5,5 +5,5 @@ class MDMDoBong(models.Model):
     _name = 'mdm.do.bong'
     _rec_name = 'ten'
 
-    ma = fields.Char("Mã", store=True)
+    ma = fields.Char("Mã", store=True, index=True)
     ten = fields.Text("Tên", store=True)

--- a/sonha_mdm/models/mdm_dvt.py
+++ b/sonha_mdm/models/mdm_dvt.py
@@ -5,5 +5,5 @@ class MDMDVT(models.Model):
     _name = 'mdm.dvt'
     _rec_name = 'ten'
 
-    ma = fields.Char("Mã", store=True)
+    ma = fields.Char("Mã", store=True, index=True)
     ten = fields.Text("Tên", store=True)

--- a/sonha_mdm/models/mdm_hh_type.py
+++ b/sonha_mdm/models/mdm_hh_type.py
@@ -5,5 +5,5 @@ class MDMHhType(models.Model):
     _name = 'mdm.hh.type'
     _rec_name = 'ten'
 
-    ma = fields.Char("Mã", store=True)
+    ma = fields.Char("Mã", store=True, index=True)
     ten = fields.Text("Tên", store=True)

--- a/sonha_mdm/models/mdm_linh_vuc.py
+++ b/sonha_mdm/models/mdm_linh_vuc.py
@@ -5,6 +5,6 @@ class MDMLinhVuc(models.Model):
     _name = 'mdm.linh.vuc'
     _rec_name = 'ten'
 
-    ma = fields.Char("Mã", store=True)
+    ma = fields.Char("Mã", store=True, index=True)
     ten = fields.Text("Tên", store=True)
     key_map = fields.Integer("Key domain")

--- a/sonha_mdm/models/mdm_nganh_hang.py
+++ b/sonha_mdm/models/mdm_nganh_hang.py
@@ -5,6 +5,6 @@ class MDMNganhHang(models.Model):
     _name = 'mdm.nganh.hang'
     _rec_name = 'ten'
 
-    ma = fields.Char("Mã", store=True)
+    ma = fields.Char("Mã", store=True, index=True)
     ten = fields.Text("Tên", store=True)
     key_map = fields.Integer("Key domain")

--- a/sonha_mdm/models/mdm_nhan_hang.py
+++ b/sonha_mdm/models/mdm_nhan_hang.py
@@ -5,6 +5,6 @@ class MDMNhanHang(models.Model):
     _name = 'mdm.nhan.hang'
     _rec_name = 'ten'
 
-    ma = fields.Char("Mã", store=True)
+    ma = fields.Char("Mã", store=True, index=True)
     ten = fields.Text("Tên", store=True)
     key_map = fields.Integer("Key domain")

--- a/sonha_mdm/models/mdm_tong_hop.py
+++ b/sonha_mdm/models/mdm_tong_hop.py
@@ -11,8 +11,8 @@ import requests
 class MDMTongHop(models.Model):
     _name = 'mdm.tong.hop'
 
-    ma = fields.Char("Mã")
-    ma_tg = fields.Char("Mã TG")
+    ma = fields.Char("Mã", index=True)
+    ma_tg = fields.Char("Mã TG", index=True)
     mdm_hh_type_id = fields.Many2one('mdm.hh.type', string="Loại hàng hóa")
     mdm_hh_type = fields.Text(related='mdm_hh_type_id.ten', string="Loại hàng hóa")
     material = fields.Char("Material Des.VI")
@@ -281,26 +281,23 @@ class MDMTongHop(models.Model):
 
         return dot / (norm1 * norm2)
 
-    @api.model
-    def create(self, vals):
-        record = super().create(vals)
-        if not record.ma:
-            record.ma = f"mdm01{record.id:010d}"
-        # if record.ma and record.dvcs:
-        #     check = self.env['mdm.khach.hang.line'].sudo().search([('ma_mdm', '=', record.ma),
-        #                                                            ('dvcs', '=', record.dvcs.id)])
-        #     if check:
-        #         check.ma_mdm = record.ma
-        #     else:
-        #         self.env['mdm.tong.hop.line'].create({
-        #             'tong_hop_id': record.id,
-        #             'ma_mdm': record.ma,
-        #             'dvcs': record.dvcs.id,
-        #         })
-        self.create_write_action_data(record)
-        self.call_api_insert(record)
+    @api.model_create_multi
+    def create(self, vals_list):
+        records = super().create(vals_list)
+        missing_ma_records = records.filtered(lambda record: not record.ma)
+        for record in missing_ma_records:
+            record.with_context(skip_mdm_similarity=True, skip_mdm_api_sync=True).write({
+                'ma': f"mdm01{record.id:010d}",
+            })
 
-        return record
+        if not self.env.context.get('skip_mdm_similarity'):
+            for record in records:
+                self.create_write_action_data(record)
+        if not self.env.context.get('skip_mdm_api_sync'):
+            for record in records:
+                self.call_api_insert(record)
+
+        return records
 
     def create_write_action_data(self, record):
         if not record.vector:
@@ -464,9 +461,12 @@ class MDMTongHop(models.Model):
 
     def write(self, vals):
         res = super().write(vals)
-        for r in self:
-            self.create_write_action_data(r)
-            self.call_api_update(r)
+        if not self.env.context.get('skip_mdm_similarity'):
+            for r in self:
+                self.create_write_action_data(r)
+        if not self.env.context.get('skip_mdm_api_sync'):
+            for r in self:
+                self.call_api_update(r)
         return res
 
     def action_view_popup(self):

--- a/sonha_mdm/models/mdm_tong_hop_import_wizard.py
+++ b/sonha_mdm/models/mdm_tong_hop_import_wizard.py
@@ -1,18 +1,28 @@
 import base64
 from io import BytesIO
 
+from openpyxl import load_workbook
+
 from odoo import _, fields, models
 from odoo.exceptions import ValidationError
-
-try:
-    from openpyxl import load_workbook
-except ImportError:
-    load_workbook = None
 
 
 class MDMTongHopImportWizard(models.TransientModel):
     _name = 'mdm.tong.hop.import.wizard'
     _description = 'Import MDM Hàng hóa từ Excel'
+
+    LOOKUP_FIELDS = (
+        ('mdm_hh_type_id', 'mdm.hh.type', 3, 'Loại hàng hóa'),
+        ('dvt', 'mdm.dvt', 6, 'Đơn vị tính'),
+        ('chung_loai1', 'mdm.chung.loai1', 7, 'Chủng loại 1'),
+        ('chung_loai2', 'mdm.chung.loai2', 8, 'Chủng loại 2'),
+        ('linh_vuc', 'mdm.linh.vuc', 9, 'Lĩnh vực'),
+        ('nganh_hang', 'mdm.nganh.hang', 10, 'Ngành hàng'),
+        ('nhan_hang', 'mdm.nhan.hang', 11, 'Nhãn hàng'),
+        ('chat_lieu', 'mdm.chat.lieu', 12, 'Chất liệu'),
+        ('do_bong', 'mdm.do.bong', 13, 'Độ bóng'),
+        ('bom_sale', 'bom.sale', 17, 'Loại trong BOM sales'),
+    )
 
     file_data = fields.Binary(string='File Excel', required=True)
     file_name = fields.Char(string='Tên file')
@@ -25,38 +35,108 @@ class MDMTongHopImportWizard(models.TransientModel):
             return value or False
         return str(value).strip() or False
 
-    def _find_many2one_by_code(self, model_name, code, field_label):
-        code = self._clean_value(code)
-        if not code:
-            return self.env[model_name].browse()
-
-        code = code.lower()
-        record = self.env[model_name].search([('ma', '=ilike', code)], limit=1)
-        if record:
-            return record
-        raise ValidationError(_('Không tìm thấy dữ liệu ở field %(field)s với mã "%(code)s".', field=field_label, code=code))
-
-
     @staticmethod
     def _merge_non_empty_vals(existing_record, incoming_vals):
         merged_vals = {}
         for field_name, value in incoming_vals.items():
+            if value in (False, None, ''):
+                continue
+
+            existing_value = existing_record[field_name]
+            if hasattr(existing_value, 'id'):
+                existing_value = existing_value.id or False
+            if existing_value != value:
+                merged_vals[field_name] = value
+
+        return merged_vals
+
+    @staticmethod
+    def _merge_non_empty_dict(base_vals, incoming_vals):
+        merged_vals = dict(base_vals)
+        for field_name, value in incoming_vals.items():
             if value not in (False, None, ''):
                 merged_vals[field_name] = value
-            elif existing_record:
-                merged_vals[field_name] = existing_record[field_name]
         return merged_vals
+
+    def _read_import_rows(self, sheet):
+        import_rows = []
+        company_codes = set()
+        lookup_codes_by_model = {model_name: set() for _, model_name, _, _ in self.LOOKUP_FIELDS}
+
+        for row_index, row in enumerate(sheet.iter_rows(min_row=2, max_col=18, values_only=True), start=2):
+            cleaned = [self._clean_value(value) for value in row]
+            if not any(cleaned):
+                continue
+
+            company_code = cleaned[0]
+            if company_code:
+                company_codes.add(company_code)
+
+            for _, model_name, column_index, _ in self.LOOKUP_FIELDS:
+                code = cleaned[column_index]
+                if code:
+                    lookup_codes_by_model[model_name].add(code.lower())
+
+            import_rows.append({
+                'row_index': row_index,
+                'company_code': company_code,
+                'ma_hang_don_vi': cleaned[1],
+                'ma_mdm': cleaned[2],
+                'values': cleaned,
+            })
+
+        return import_rows, company_codes, lookup_codes_by_model
+
+    def _get_lookup_cache(self, lookup_codes_by_model):
+        lookup_cache = {}
+        for model_name, codes in lookup_codes_by_model.items():
+            if not codes:
+                lookup_cache[model_name] = {}
+                continue
+
+            records = self.env[model_name].sudo().search([('ma', '!=', False)])
+            lookup_cache[model_name] = {
+                record.ma.strip().lower(): record.id
+                for record in records
+                if record.ma and record.ma.strip().lower() in codes
+            }
+
+        return lookup_cache
+
+    def _get_lookup_id(self, lookup_cache, model_name, code, field_label):
+        if not code:
+            return False
+
+        lookup_id = lookup_cache.get(model_name, {}).get(code.lower())
+        if lookup_id:
+            return lookup_id
+
+        raise ValidationError(_('Không tìm thấy dữ liệu ở field %(field)s với mã "%(code)s".', field=field_label, code=code))
+
+    def _prepare_vals(self, row_data, lookup_cache):
+        row_values = row_data['values']
+        vals = {
+            'ma_tg': row_data['ma_hang_don_vi'],
+            'ma': row_data['ma_mdm'],
+            'ten_ngan': row_values[4],
+            'ten': row_values[5],
+            'do_day': row_values[14],
+            'dung_tich_plus': row_values[15],
+            'dvt_dung_tich': row_values[16],
+        }
+
+        for field_name, model_name, column_index, field_label in self.LOOKUP_FIELDS:
+            vals[field_name] = self._get_lookup_id(lookup_cache, model_name, row_values[column_index], field_label)
+
+        return vals
 
     def action_import(self):
         self.ensure_one()
 
-        if load_workbook is None:
-            raise ValidationError(_('Thiếu thư viện openpyxl để đọc file Excel.'))
-
         if not self.file_data:
             raise ValidationError(_('Vui lòng chọn file Excel để import.'))
 
-        workbook = load_workbook(filename=BytesIO(base64.b64decode(self.file_data)), data_only=True)
+        workbook = load_workbook(filename=BytesIO(base64.b64decode(self.file_data)), read_only=True, data_only=True)
         sheet = workbook.active
 
         model = self.env['mdm.tong.hop']
@@ -66,14 +146,7 @@ class MDMTongHopImportWizard(models.TransientModel):
         updated = 0
         errors = []
 
-        rows = list(sheet.iter_rows(min_row=2, values_only=True))
-        company_codes = set()
-        for row in rows:
-            if not any(self._clean_value(cell) for cell in row[:18]):
-                continue
-            company_code = self._clean_value(row[0] if len(row) > 0 else False)
-            if company_code:
-                company_codes.add(company_code)
+        import_rows, company_codes, lookup_codes_by_model = self._read_import_rows(sheet)
 
         if len(company_codes) > 1:
             raise ValidationError(_('File không cùng 1 mã công ty. Vui lòng kiểm tra lại cột mã công ty trong file import.'))
@@ -82,67 +155,82 @@ class MDMTongHopImportWizard(models.TransientModel):
             raise ValidationError(_('Thiếu mã công ty trong file import.'))
 
         company_code = next(iter(company_codes))
-        company = self.env['res.company'].search([('company_code', '=', company_code)], limit=1)
+        company = self.env['res.company'].sudo().search([('company_code', '=', company_code)], limit=1)
         if not company:
             raise ValidationError(_('Không tìm thấy công ty với mã công ty "%(code)s".', code=company_code))
 
-        for row_index, row in enumerate(rows, start=2):
-            ma_hang_don_vi = self._clean_value(row[1] if len(row) > 1 else False)
-            ma_mdm = self._clean_value(row[2] if len(row) > 2 else False)
+        lookup_cache = self._get_lookup_cache(lookup_codes_by_model)
+        ma_mdm_values = {row_data['ma_mdm'] for row_data in import_rows if row_data['ma_mdm']}
+        existing_by_ma = {
+            record.ma: record
+            for record in model.sudo().search([('ma', 'in', list(ma_mdm_values))])
+        }
 
-            if not any(self._clean_value(cell) for cell in row[:18]):
-                continue
+        pending_create_vals_by_ma = {}
+        prepared_rows = []
+        import_context = {
+            'skip_mdm_similarity': True,
+            'skip_mdm_api_sync': True,
+        }
 
-            vals = {
-                'ma_tg': ma_hang_don_vi,
-                'ma': ma_mdm,
-                'mdm_hh_type_id': self._find_many2one_by_code('mdm.hh.type', row[3] if len(row) > 3 else False, 'Loại hàng hóa').id,
-                'ten_ngan': self._clean_value(row[4] if len(row) > 4 else False),
-                'ten': self._clean_value(row[5] if len(row) > 5 else False),
-                'dvt': self._find_many2one_by_code('mdm.dvt', row[6] if len(row) > 6 else False, 'Đơn vị tính').id,
-                'chung_loai1': self._find_many2one_by_code('mdm.chung.loai1', row[7] if len(row) > 7 else False, 'Chủng loại 1').id,
-                'chung_loai2': self._find_many2one_by_code('mdm.chung.loai2', row[8] if len(row) > 8 else False, 'Chủng loại 2').id,
-                'linh_vuc': self._find_many2one_by_code('mdm.linh.vuc', row[9] if len(row) > 9 else False, 'Lĩnh vực').id,
-                'nganh_hang': self._find_many2one_by_code('mdm.nganh.hang', row[10] if len(row) > 10 else False, 'Ngành hàng').id,
-                'nhan_hang': self._find_many2one_by_code('mdm.nhan.hang', row[11] if len(row) > 11 else False, 'Nhãn hàng').id,
-                'chat_lieu': self._find_many2one_by_code('mdm.chat.lieu', row[12] if len(row) > 12 else False, 'Chất liệu').id,
-                'do_bong': self._find_many2one_by_code('mdm.do.bong', row[13] if len(row) > 13 else False, 'Độ bóng').id,
-                'do_day': self._clean_value(row[14] if len(row) > 14 else False),
-                'dung_tich_plus': self._clean_value(row[15] if len(row) > 15 else False),
-                'dvt_dung_tich': self._clean_value(row[16] if len(row) > 16 else False),
-                'bom_sale': self._find_many2one_by_code('bom.sale', row[17] if len(row) > 17 else False, 'Loại trong BOM sales').id,
-            }
-
+        for row_data in import_rows:
+            ma_mdm = row_data['ma_mdm']
             try:
                 if not ma_mdm:
                     raise ValidationError(_('Thiếu Mã MDM ở cột C.'))
 
-                existing = model.search([('ma', '=', ma_mdm)], limit=1)
+                vals = self._prepare_vals(row_data, lookup_cache)
+                existing = existing_by_ma.get(ma_mdm)
 
                 if existing:
-                    parent_record = existing
                     update_vals = self._merge_non_empty_vals(existing, vals)
-                    parent_record.sudo().write(dict(update_vals, dvcs=company.id))
+                    if existing.dvcs.id != company.id:
+                        update_vals['dvcs'] = company.id
+                    if update_vals:
+                        existing.with_context(**import_context).sudo().write(update_vals)
                     updated += 1
                 else:
-                    parent_record = model.create(dict(vals, dvcs=company.id))
-                    imported += 1
+                    current_create_vals = dict(vals, dvcs=company.id)
+                    if ma_mdm in pending_create_vals_by_ma:
+                        pending_create_vals_by_ma[ma_mdm] = self._merge_non_empty_dict(
+                            pending_create_vals_by_ma[ma_mdm],
+                            current_create_vals,
+                        )
+                    else:
+                        pending_create_vals_by_ma[ma_mdm] = current_create_vals
+                        imported += 1
 
-                line_vals = {
-                    'tong_hop_id': parent_record.id,
-                    'ma_mdm': ma_mdm,
-                    'dvcs': company.id,
-                }
-                if ma_hang_don_vi:
-                    line_vals['ma_dv'] = ma_hang_don_vi
-
-                line_model.create(line_vals)
+                prepared_rows.append(row_data)
             except Exception as exc:
-                errors.append(_('Dòng %(row)s (Mã MDM: %(ma_mdm)s): %(error)s', row=row_index, ma_mdm=ma_mdm or '-', error=str(exc)))
+                errors.append(_('Dòng %(row)s (Mã MDM: %(ma_mdm)s): %(error)s', row=row_data['row_index'], ma_mdm=ma_mdm or '-', error=str(exc)))
 
-        message = _('Import hoàn tất. Tạo mới: %(new)s, Cập nhật: %(updated)s', new=imported, updated=updated)
         if errors:
+            message = _('Import hoàn tất. Tạo mới: %(new)s, Cập nhật: %(updated)s', new=imported, updated=updated)
             message = message + '\n' + '\n'.join(errors[:20])
             raise ValidationError(message)
+
+        created_by_ma = {}
+        if pending_create_vals_by_ma:
+            created_records = model.with_context(**import_context).sudo().create(list(pending_create_vals_by_ma.values()))
+            created_by_ma = {record.ma: record for record in created_records}
+
+        line_vals_list = []
+        for row_data in prepared_rows:
+            ma_mdm = row_data['ma_mdm']
+            parent_record = existing_by_ma.get(ma_mdm) or created_by_ma.get(ma_mdm)
+            if not parent_record:
+                continue
+
+            line_vals = {
+                'tong_hop_id': parent_record.id,
+                'ma_mdm': ma_mdm,
+                'dvcs': company.id,
+            }
+            if row_data['ma_hang_don_vi']:
+                line_vals['ma_dv'] = row_data['ma_hang_don_vi']
+            line_vals_list.append(line_vals)
+
+        if line_vals_list:
+            line_model.sudo().create(line_vals_list)
 
         return {'type': 'ir.actions.act_window_close'}

--- a/sonha_mdm/models/mdm_tong_hop_line.py
+++ b/sonha_mdm/models/mdm_tong_hop_line.py
@@ -5,7 +5,7 @@ class MDMTongHopLine(models.Model):
     _name = 'mdm.tong.hop.line'
     _description = 'Bảng con MDM hàng hóa'
 
-    tong_hop_id = fields.Many2one('mdm.tong.hop', string='Hàng hóa', ondelete='cascade')
-    ma_mdm = fields.Char(string='Mã MDM')
-    ma_dv = fields.Char(string='Mã đơn vị')
-    dvcs = fields.Many2one('res.company', string='ĐVCS')
+    tong_hop_id = fields.Many2one('mdm.tong.hop', string='Hàng hóa', ondelete='cascade', index=True)
+    ma_mdm = fields.Char(string='Mã MDM', index=True)
+    ma_dv = fields.Char(string='Mã đơn vị', index=True)
+    dvcs = fields.Many2one('res.company', string='ĐVCS', index=True)


### PR DESCRIPTION
### Motivation
- Import Excel hiện tại chậm với vài nghìn bản ghi do nhiều tìm kiếm ORM/SQL trên mỗi dòng và các xử lý nặng (tính similarity, gọi API) chạy đồng bộ trong vòng lặp.

### Description
- Đọc workbook ở chế độ `read_only` và làm sạch/chuẩn bị tất cả dòng chỉ một lần để tránh lặp I/O/CPU không cần thiết.
- Cache lookup cho các bảng danh mục (theo `LOOKUP_FIELDS`) và prefetch tất cả sản phẩm tồn tại với một truy vấn `search([('ma','in', ...)])` thay cho `search` per-row.
- Gom các bản ghi mới theo `ma` để tạo batch (`create(list(...))`) và tạo batch cho các dòng con `mdm.tong.hop.line` thay vì gọi `create` từng dòng; với các bản ghi cần cập nhật chỉ `write` các field thực sự khác nhau để giảm số lần ghi.
- Thêm `@api.model_create_multi` cho `mdm.tong.hop.create` và flag context `skip_mdm_similarity` / `skip_mdm_api_sync` để bỏ qua việc tính similarity và gọi API khi import hàng loạt, đồng thời giữ hành vi cũ khi thao tác UI bình thường; `write` cũng tôn trọng các flag này.
- Thêm index trên các trường được lookup/filter nhiều (`ma`, `ma_tg`, các trường bảng con và `ma` của các danh mục) để tăng tốc các truy vấn cơ sở dữ liệu liên quan đến import.

### Testing
- Kiểm tra cú pháp bằng `ast.parse` trên tất cả file trong `sonha_mdm/models` đã chạy thành công.
- Biên dịch bằng `py_compile` / `compileall` để đảm bảo các module Python hợp lệ và không lỗi cú pháp, kết quả thành công.
- Chạy `git diff --check` để kiểm tra whitespace/format issues và không báo lỗi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f9b0900e0832daa71d79ac1620b4a)