### PR TITLE
Call item insert API for new unit lines

### DIFF
--- a/sonha_mdm/models/mdm_tong_hop.py
+++ b/sonha_mdm/models/mdm_tong_hop.py
@@ -371,8 +371,9 @@ class MDMTongHop(models.Model):
         for r in self:
             self.create_write_action_data(r)
 
-    def call_api_insert(self, record):
-        data = {'ma_chung_loai1': record.chung_loai1.ma or None,
+    def _prepare_api_payload(self, record, sync_type, line=None):
+        company = line.dvcs if line and line.dvcs else record.dvcs
+        return {'ma_chung_loai1': record.chung_loai1.ma or None,
                 'ten_chung_loai1': record.chung_loai1.ten or None,
                 'ma_chung_loai2': record.chung_loai2.ma or None,
                 'ten_chung_loai2': record.chung_loai2.ten or None,
@@ -384,14 +385,15 @@ class MDMTongHop(models.Model):
                 'ten_nhan_hang': record.nhan_hang.ten or None,
                 'ma': record.ma or None,
                 'ten': record.ten or None,
-                'ma_tg': record.ma_tg or None,
+                'ma_tg': (line.ma_dv or None) if line else (record.ma_tg or None),
                 'ten_ngan': record.ten_ngan or None,
                 'dvt': record.dvt.ma or None,
-                'ma_dvcs': record.dvcs.company_code or None,
-                'ten_dvcs': record.dvcs.name or None,
-                'type': 'insert',
+                'ma_dvcs': company.company_code or None,
+                'ten_dvcs': company.name or None,
+                'type': sync_type,
                 }
 
+    def _call_api_hang_hoa(self, data, success_log, error_log):
         # 👉 convert sang JSON string
         json_str = json.dumps(data, ensure_ascii=False)
 
@@ -409,53 +411,18 @@ class MDMTongHop(models.Model):
             )
 
             # debug
-            print("API RESPONSE:", response.text)
+            print(success_log, response.text)
 
         except Exception as e:
-            print("API ERROR:", str(e))
+            print(error_log, str(e))
+
+    def call_api_insert(self, record, line=None):
+        data = self._prepare_api_payload(record, 'insert', line=line)
+        self._call_api_hang_hoa(data, "API RESPONSE:", "API ERROR:")
 
     def call_api_update(self, record):
-        data = {'ma_chung_loai1': record.chung_loai1.ma or None,
-                'ten_chung_loai1': record.chung_loai1.ten or None,
-                'ma_chung_loai2': record.chung_loai2.ma or None,
-                'ten_chung_loai2': record.chung_loai2.ten or None,
-                'ma_linh_vuc': record.linh_vuc.ma or None,
-                'ten_linh_vuc': record.linh_vuc.ten or None,
-                'ma_nganh_hang': record.nganh_hang.ma or None,
-                'ten_nganh_hang': record.nganh_hang.ten or None,
-                'ma_nhan_hang': record.nhan_hang.ma or None,
-                'ten_nhan_hang': record.nhan_hang.ten or None,
-                'ma': record.ma or None,
-                'ten': record.ten or None,
-                'ma_tg': record.ma_tg or None,
-                'ten_ngan': record.ten_ngan or None,
-                'dvt': record.dvt.ma or None,
-                'ma_dvcs': record.dvcs.company_code or None,
-                'ten_dvcs': record.dvcs.name or None,
-                'type': 'update',
-                }
-
-        # 👉 convert sang JSON string
-        json_str = json.dumps(data, ensure_ascii=False)
-
-        # 🔥 thêm dấu ' 2 bên (theo yêu cầu API của bạn)
-        payload = f"'{json_str}'"
-
-        try:
-            response = requests.put(
-                "https://bhapi.sonha.com.vn/api/mdm_hh",
-                json=payload,
-                headers={
-                    'Content-Type': 'application/json; charset=utf-8'
-                },
-                timeout=10
-            )
-
-            # debug
-            print("API hàng hóa:", response.text)
-
-        except Exception as e:
-            print("API hàng hóa:", str(e))
+        data = self._prepare_api_payload(record, 'update')
+        self._call_api_hang_hoa(data, "API hàng hóa:", "API hàng hóa:")
 
     def write(self, vals):
         res = super().write(vals)

--- a/sonha_mdm/models/mdm_tong_hop_line.py
+++ b/sonha_mdm/models/mdm_tong_hop_line.py
@@ -1,4 +1,4 @@
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class MDMTongHopLine(models.Model):
@@ -13,3 +13,11 @@ class MDMTongHopLine(models.Model):
 
     dvt = fields.Many2one('mdm.dvt', string="Đơn vị tính", related='tong_hop_id.dvt', store=True)
     bom_sale = fields.Many2one('bom.sale',  string="Loại Bom Sale", related='tong_hop_id.bom_sale', store=True)
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        records = super().create(vals_list)
+        if not self.env.context.get('skip_mdm_api_sync'):
+            for record in records.filtered('tong_hop_id'):
+                record.tong_hop_id.call_api_insert(record.tong_hop_id, line=record)
+        return records


### PR DESCRIPTION
### Motivation
- Ensure the external MDM item API is called when a new unit line is added to an existing product so the API receives unit-specific values. 
- Reduce duplication by centralizing payload building and HTTP call logic for `insert` and `update` flows. 
- Make the insert payload prefer child-line fields (`ma_dv`, `dvcs`) when a unit line triggers the sync while preserving existing behavior when called from the parent record.

### Description
- Added `_prepare_api_payload(record, sync_type, line=None)` and `_call_api_hang_hoa(data, success_log, error_log)` helpers in `sonha_mdm/models/mdm_tong_hop.py` to centralize payload creation and the HTTP call. 
- Updated `call_api_insert` to accept an optional `line` parameter and `call_api_update` to use the shared helpers so `ma_tg` and company fields come from the child `line` when provided. 
- Added `@api.model_create_multi def create` override in `sonha_mdm/models/mdm_tong_hop_line.py` to invoke the parent `call_api_insert` for newly created unit lines unless the context contains `skip_mdm_api_sync`.

### Testing
- Ran Python bytecode compilation with `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile sonha_mdm/models/mdm_tong_hop.py sonha_mdm/models/mdm_tong_hop_line.py` and it succeeded. 
- Ran style/sanity check with `git diff --check` and there were no issues reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1fdbb0d3f4832d98d98b1db49a2f11)