### PR TITLE
Thêm job cron re-sync API MDM cho hàng hóa và khách hàng và ghi nhận kết quả

### DIFF
--- a/sonha_mdm/data/cron_job.xml
+++ b/sonha_mdm/data/cron_job.xml
@@ -35,5 +35,29 @@
             <field name="numbercall">-1</field>
             <field name="active">false</field>
         </record>
+
+        <record id="ir_cron_call_api_insert_hang_hoa" model="ir.cron">
+            <field name="name">Call API insert toàn bộ MDM hàng hóa</field>
+            <field name="model_id" ref="model_mdm_tong_hop"/>
+            <field name="state">code</field>
+            <field name="code">model.cron_call_api_insert_all_hang_hoa()</field>
+            <field name="user_id" ref="base.user_root"/>
+            <field name="interval_number">1</field>
+            <field name="interval_type">days</field>
+            <field name="numbercall">-1</field>
+            <field name="active">false</field>
+        </record>
+
+        <record id="ir_cron_call_api_insert_khach_hang" model="ir.cron">
+            <field name="name">Call API insert toàn bộ MDM khách hàng</field>
+            <field name="model_id" ref="model_mdm_khach_hang"/>
+            <field name="state">code</field>
+            <field name="code">model.cron_call_api_insert_all_khach_hang()</field>
+            <field name="user_id" ref="base.user_root"/>
+            <field name="interval_number">1</field>
+            <field name="interval_type">days</field>
+            <field name="numbercall">-1</field>
+            <field name="active">false</field>
+        </record>
     </data>
 </odoo>

--- a/sonha_mdm/models/mdm_khach_hang.py
+++ b/sonha_mdm/models/mdm_khach_hang.py
@@ -47,6 +47,9 @@ class MDMKhachHang(models.Model):
 
     current_step = fields.Integer(string="STT hiện tại", default=1)
     can_approve = fields.Boolean(compute='_compute_can_approve')
+    da_call_api = fields.Boolean(string="Đã call API", copy=False, readonly=True)
+    thoi_gian_call_api = fields.Datetime(string="Thời gian call API", copy=False, readonly=True)
+    ket_qua_call_api = fields.Text(string="Kết quả call API", copy=False, readonly=True)
 
 
     # update thêm code
@@ -446,17 +449,42 @@ class MDMKhachHang(models.Model):
 
             # debug
             print(success_log, response.text)
+            return response.ok, response.text
 
         except Exception as e:
-            print(error_log, str(e))
+            error_message = str(e)
+            print(error_log, error_message)
+            return False, error_message
+
+    def _mark_api_result(self, record, success, message, line=None):
+        values = {
+            'da_call_api': success,
+            'thoi_gian_call_api': fields.Datetime.now(),
+            'ket_qua_call_api': message,
+        }
+        target = line or record
+        target.with_context(skip_mdm_similarity=True, skip_mdm_api_sync=True).sudo().write(values)
 
     def call_api_insert(self, record, line=None):
         data = self._prepare_api_payload(record, 'insert', line=line)
-        self._call_api_khach_hang(data, "API RESPONSE:", "API ERROR:")
+        success, message = self._call_api_khach_hang(data, "API RESPONSE:", "API ERROR:")
+        self._mark_api_result(record, success, message, line=line)
+        return success
 
     def call_api_update(self, record):
         data = self._prepare_api_payload(record, 'update')
-        self._call_api_khach_hang(data, "API RESPONSE:", "API ERROR:")
+        success, message = self._call_api_khach_hang(data, "API RESPONSE:", "API ERROR:")
+        self._mark_api_result(record, success, message)
+        return success
+
+    @api.model
+    def cron_call_api_insert_all_khach_hang(self, limit=None):
+        records = self.search([], limit=limit)
+        for record in records:
+            record.call_api_insert(record)
+            for line in record.bang_con_ids:
+                record.call_api_insert(record, line=line)
+        return True
 
     def action_view_popup(self):
         self.ensure_one()

--- a/sonha_mdm/models/mdm_khach_hang_line.py
+++ b/sonha_mdm/models/mdm_khach_hang_line.py
@@ -9,6 +9,9 @@ class MDMKhachHangLine(models.Model):
     ma_mdm = fields.Char(string='Mã MDM')
     ma_dv = fields.Char(string='Mã đơn vị')
     dvcs = fields.Many2one('res.company', string='ĐVCS')
+    da_call_api = fields.Boolean(string="Đã call API", copy=False, readonly=True)
+    thoi_gian_call_api = fields.Datetime(string="Thời gian call API", copy=False, readonly=True)
+    ket_qua_call_api = fields.Text(string="Kết quả call API", copy=False, readonly=True)
 
     @api.model_create_multi
     def create(self, vals_list):

--- a/sonha_mdm/models/mdm_tong_hop.py
+++ b/sonha_mdm/models/mdm_tong_hop.py
@@ -68,6 +68,9 @@ class MDMTongHop(models.Model):
 
     current_step = fields.Integer(string="STT hiện tại", default=1)
     can_approve = fields.Boolean(compute='_compute_can_approve')
+    da_call_api = fields.Boolean(string="Đã call API", copy=False, readonly=True)
+    thoi_gian_call_api = fields.Datetime(string="Thời gian call API", copy=False, readonly=True)
+    ket_qua_call_api = fields.Text(string="Kết quả call API", copy=False, readonly=True)
 
     def _compute_can_approve(self):
         for rec in self:
@@ -412,17 +415,42 @@ class MDMTongHop(models.Model):
 
             # debug
             print(success_log, response.text)
+            return response.ok, response.text
 
         except Exception as e:
-            print(error_log, str(e))
+            error_message = str(e)
+            print(error_log, error_message)
+            return False, error_message
+
+    def _mark_api_result(self, record, success, message, line=None):
+        values = {
+            'da_call_api': success,
+            'thoi_gian_call_api': fields.Datetime.now(),
+            'ket_qua_call_api': message,
+        }
+        target = line or record
+        target.with_context(skip_mdm_similarity=True, skip_mdm_api_sync=True).sudo().write(values)
 
     def call_api_insert(self, record, line=None):
         data = self._prepare_api_payload(record, 'insert', line=line)
-        self._call_api_hang_hoa(data, "API RESPONSE:", "API ERROR:")
+        success, message = self._call_api_hang_hoa(data, "API RESPONSE:", "API ERROR:")
+        self._mark_api_result(record, success, message, line=line)
+        return success
 
     def call_api_update(self, record):
         data = self._prepare_api_payload(record, 'update')
-        self._call_api_hang_hoa(data, "API hàng hóa:", "API hàng hóa:")
+        success, message = self._call_api_hang_hoa(data, "API hàng hóa:", "API hàng hóa:")
+        self._mark_api_result(record, success, message)
+        return success
+
+    @api.model
+    def cron_call_api_insert_all_hang_hoa(self, limit=None):
+        records = self.search([], limit=limit)
+        for record in records:
+            record.call_api_insert(record)
+            for line in record.bang_con_ids:
+                record.call_api_insert(record, line=line)
+        return True
 
     def write(self, vals):
         res = super().write(vals)

--- a/sonha_mdm/models/mdm_tong_hop_line.py
+++ b/sonha_mdm/models/mdm_tong_hop_line.py
@@ -13,6 +13,9 @@ class MDMTongHopLine(models.Model):
 
     dvt = fields.Many2one('mdm.dvt', string="Đơn vị tính", related='tong_hop_id.dvt', store=True)
     bom_sale = fields.Many2one('bom.sale',  string="Loại Bom Sale", related='tong_hop_id.bom_sale', store=True)
+    da_call_api = fields.Boolean(string="Đã call API", copy=False, readonly=True)
+    thoi_gian_call_api = fields.Datetime(string="Thời gian call API", copy=False, readonly=True)
+    ket_qua_call_api = fields.Text(string="Kết quả call API", copy=False, readonly=True)
 
     @api.model_create_multi
     def create(self, vals_list):

--- a/sonha_mdm/views/mdm_khach_hang_views.xml
+++ b/sonha_mdm/views/mdm_khach_hang_views.xml
@@ -35,6 +35,8 @@
                     <group>
                         <field name="mst"/>
                         <field name="cccd"/>
+                        <field name="da_call_api"/>
+                        <field name="thoi_gian_call_api"/>
                     </group>
                 </group>
                 <notebook>
@@ -59,6 +61,8 @@
                                 <field name="ma_mdm" readonly="1"/>
                                 <field name="ma_dv"/>
                                 <field name="dvcs" readonly="1"/>
+                                <field name="da_call_api" readonly="1"/>
+                                <field name="thoi_gian_call_api" readonly="1"/>
                             </tree>
                         </field>
                     </page>
@@ -152,6 +156,8 @@
                 <field name="khu_vuc" optional="show"/>
                 <field name="mien_lon" optional="show"/>
                 <field name="mien_nho" optional="show"/>
+                <field name="da_call_api" optional="show"/>
+                <field name="thoi_gian_call_api" optional="hide"/>
             </tree>
         </field>
     </record>

--- a/sonha_mdm/views/mdm_tong_hop_views.xml
+++ b/sonha_mdm/views/mdm_tong_hop_views.xml
@@ -40,6 +40,8 @@
                             <field name="linh_vuc" domain="[('key_map', '=', key_linh_vuc)]" options="{'no_create': True, 'no_open': True}"/>
                             <field name="nganh_hang" domain="[('key_map', '=', key_nganh_hang)]" options="{'no_create': True, 'no_open': True}"/>
                             <field name="nhan_hang" domain="[('key_map', '=', key_nhan_hang)]" options="{'no_create': True, 'no_open': True}"/>
+                            <field name="da_call_api"/>
+                            <field name="thoi_gian_call_api"/>
                         </group>
 
                     </group>
@@ -65,6 +67,8 @@
                                 <field name="ma_mdm" readonly="1"/>
                                 <field name="ma_dv"/>
                                 <field name="dvcs" readonly="1"/>
+                                <field name="da_call_api" readonly="1"/>
+                                <field name="thoi_gian_call_api" readonly="1"/>
                             </tree>
                         </field>
                     </page>
@@ -150,6 +154,8 @@
                 <field name="dung_tich_plus" optional="show"/>
                 <field name="dvt_dung_tich" optional="show"/>
                 <field name="bom_sale" optional="show"/>
+                <field name="da_call_api" optional="show"/>
+                <field name="thoi_gian_call_api" optional="hide"/>
             </tree>
         </field>
     </record>


### PR DESCRIPTION
### Motivation
- Cần một cách để gọi lại API `insert` cho toàn bộ dữ liệu hai bảng MDM (hàng hóa, khách hàng) khi dữ liệu đã có sẵn, và cần đánh dấu những bản ghi/dòng nào đã được call thành công hoặc lỗi để dễ kiểm tra và chạy lại thủ công.

### Description
- Thêm 3 trường trạng thái `da_call_api`, `thoi_gian_call_api`, `ket_qua_call_api` cho cả hai model chính `mdm.tong.hop` / `mdm.khach.hang` và cho các dòng con `mdm.tong.hop.line` / `mdm.khach.hang.line` để lưu kết quả gọi API trên bản ghi chính và trên từng mã đơn vị; các trường này ghi bằng `sudo()` với context `skip_mdm_similarity`/`skip_mdm_api_sync`.
- Cập nhật hàm `_call_api_hang_hoa` / `_call_api_khach_hang` để trả về tuple `(success_boolean, message)` khi gọi `requests.put`, và thêm helper `_mark_api_result` để cập nhật các trường trạng thái; `call_api_insert`/`call_api_update` bây giờ gọi helper và trả về `success`.
- Thêm 2 method cron `cron_call_api_insert_all_hang_hoa` và `cron_call_api_insert_all_khach_hang` (mặc định `limit=None`) để lặp qua tất cả bản ghi và các dòng con, gọi lại `call_api_insert(record)` và `call_api_insert(record, line=line)` theo logic hiện có.
- Thêm 2 scheduled actions (cron) inactive trong `data/cron_job.xml` để bật thủ công khi cần; cập nhật views `mdm_tong_hop` và `mdm_khach_hang` để hiển thị `Đã call API` và `Thời gian call API` ở form/list và trong tab "Bảng con đơn vị".

### Testing
- Biên dịch Python với `python -m py_compile sonha_mdm/models/mdm_tong_hop.py sonha_mdm/models/mdm_khach_hang.py sonha_mdm/models/mdm_tong_hop_line.py sonha_mdm/models/mdm_khach_hang_line.py` — kết quả OK.
- Kiểm tra parse XML cho file cron và views bằng `xml.etree.ElementTree.parse(...)` — các file XML hợp lệ.
- Chạy `git diff --check` / lint diff checks — không phát hiện vấn đề cú pháp trong diff.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a226cf3a7248324b8383228dea471b7)