### PR TITLE
Handle time-based word slips across midnight and use UTC-aware check-in/out computation

### DIFF
--- a/sonha_word_slip/models/employee_attendance_v2.py
+++ b/sonha_word_slip/models/employee_attendance_v2.py
@@ -700,7 +700,7 @@ class EmployeeAttendanceV2(models.Model):
                 r.check_no_out = split_utc
 
     def _float_time_to_local_datetime(self, base_date, hour_float):
-        if base_date is None or hour_float in (None, False):
+        if base_date is None or hour_float is None:
             return None
         if not isinstance(hour_float, (int, float)) or hour_float < 0:
             raise ValueError(f"Invalid time value: {hour_float}")
@@ -712,12 +712,20 @@ class EmployeeAttendanceV2(models.Model):
             minute = minute % 60
         return datetime.combine(base_date, time(0, 0, 0)) + timedelta(hours=hour, minutes=minute)
 
-    def _get_time_word_slip_points_utc(self, word_slip):
-        check_in = self._float_time_to_local_datetime(word_slip.from_date, word_slip.time_to)
-        check_out = self._float_time_to_local_datetime(word_slip.to_date, word_slip.time_from)
-        if check_in and check_out and check_out <= check_in:
-            check_out += timedelta(days=1)
-        return self._to_utc_datetime(check_in), self._to_utc_datetime(check_out)
+    def _get_time_word_slip_pairs_utc(self, word_slip):
+        if not word_slip.from_date or not word_slip.to_date:
+            return []
+
+        pairs = []
+        current_date = word_slip.from_date
+        while current_date <= word_slip.to_date:
+            check_in = self._float_time_to_local_datetime(current_date, word_slip.time_to)
+            check_out = self._float_time_to_local_datetime(current_date, word_slip.time_from)
+            if check_in and check_out and check_out <= check_in:
+                check_out += timedelta(days=1)
+            pairs.append((self._to_utc_datetime(check_in), self._to_utc_datetime(check_out)))
+            current_date += timedelta(days=1)
+        return pairs
 
     def _get_time_word_slips_in_window(self, employee, window_start_utc, window_end_utc):
         if not employee or not window_start_utc or not window_end_utc:
@@ -727,7 +735,7 @@ class EmployeeAttendanceV2(models.Model):
         window_end_local = self._to_local_datetime(window_end_utc)
         word_slips = self.env['word.slip'].sudo().search([
             ('from_date', '<=', window_end_local.date()),
-            ('to_date', '>=', window_start_local.date()),
+            ('to_date', '>=', window_start_local.date() - timedelta(days=1)),
             ('type.date_and_time', '=', 'time'),
             ('word_slip.status', '=', 'done'),
         ])
@@ -737,7 +745,8 @@ class EmployeeAttendanceV2(models.Model):
         return word_slips.filtered(
             lambda line: any(
                 window_start_utc <= point <= window_end_utc
-                for point in self._get_time_word_slip_points_utc(line)
+                for pair in self._get_time_word_slip_pairs_utc(line)
+                for point in pair
                 if point
             )
         )
@@ -772,14 +781,14 @@ class EmployeeAttendanceV2(models.Model):
 
             in_outs = self._get_time_word_slips_in_window(r.employee_id, r.time_check_in, r.time_check_out)
             for in_out in in_outs:
-                ci, co = self._get_time_word_slip_points_utc(in_out)
-                if (ci and r.time_check_in <= ci <= r.time_check_out and r.check_no_in and ci <= r.check_no_in
-                        and (not check_in or check_in > ci)):
-                    check_in = ci
+                for ci, co in self._get_time_word_slip_pairs_utc(in_out):
+                    if (ci and r.time_check_in <= ci <= r.time_check_out and r.check_no_in and ci <= r.check_no_in
+                            and (not check_in or check_in > ci)):
+                        check_in = ci
 
-                if (co and r.time_check_in <= co <= r.time_check_out and r.check_no_out and co > r.check_no_out
-                        and (not check_out or check_out < co)):
-                    check_out = co
+                    if (co and r.time_check_in <= co <= r.time_check_out and r.check_no_out and co > r.check_no_out
+                            and (not check_out or check_out < co)):
+                        check_out = co
 
             r.check_in = check_in
             r.check_out = check_out

--- a/sonha_word_slip/models/employee_attendance_v2.py
+++ b/sonha_word_slip/models/employee_attendance_v2.py
@@ -699,24 +699,52 @@ class EmployeeAttendanceV2(models.Model):
                 r.check_no_in = split_utc
                 r.check_no_out = split_utc
 
+    def _float_time_to_local_datetime(self, base_date, hour_float):
+        if base_date is None or hour_float in (None, False):
+            return None
+        if not isinstance(hour_float, (int, float)) or hour_float < 0:
+            raise ValueError(f"Invalid time value: {hour_float}")
+
+        hour = int(hour_float)
+        minute = int(round((hour_float % 1) * 60))
+        if minute >= 60:
+            hour += minute // 60
+            minute = minute % 60
+        return datetime.combine(base_date, time(0, 0, 0)) + timedelta(hours=hour, minutes=minute)
+
+    def _get_time_word_slip_points_utc(self, word_slip):
+        check_in = self._float_time_to_local_datetime(word_slip.from_date, word_slip.time_to)
+        check_out = self._float_time_to_local_datetime(word_slip.to_date, word_slip.time_from)
+        if check_in and check_out and check_out <= check_in:
+            check_out += timedelta(days=1)
+        return self._to_utc_datetime(check_in), self._to_utc_datetime(check_out)
+
+    def _get_time_word_slips_in_window(self, employee, window_start_utc, window_end_utc):
+        if not employee or not window_start_utc or not window_end_utc:
+            return self.env['word.slip']
+
+        window_start_local = self._to_local_datetime(window_start_utc)
+        window_end_local = self._to_local_datetime(window_end_utc)
+        word_slips = self.env['word.slip'].sudo().search([
+            ('from_date', '<=', window_end_local.date()),
+            ('to_date', '>=', window_start_local.date()),
+            ('type.date_and_time', '=', 'time'),
+            ('word_slip.status', '=', 'done'),
+        ])
+        word_slips = word_slips.filtered(
+            lambda x: (x.word_slip.employee_id and x.word_slip.employee_id.id == employee.id) or (
+                    x.word_slip.employee_ids and employee.id in x.word_slip.employee_ids.ids))
+        return word_slips.filtered(
+            lambda line: any(
+                window_start_utc <= point <= window_end_utc
+                for point in self._get_time_word_slip_points_utc(line)
+                if point
+            )
+        )
+
     # Lấy thông tin check-in và check-out của nhân viên
     @api.depends('employee_id', 'time_check_in', 'time_check_out', 'check_no_in', 'check_no_out')
     def _get_check_in_out(self):
-        def calculate_time(input_time, date, default_time):
-            if not isinstance(input_time, (int, float)) or input_time < 0:
-                raise ValueError(f"Invalid time value: {input_time}")
-
-            hour = int(input_time)
-            minute = int(round((input_time % 1) * 60))
-            if minute >= 60:
-                hour += minute // 60
-                minute = minute % 60
-            if hour >= 24:
-                return datetime.combine(date, time(0, 0, 0)) + timedelta(days=1, hours=hour - 24, minutes=minute)
-            if 0 <= hour < 24:
-                return datetime.combine(date, time(hour, minute, 0))
-            return default_time
-
         for r in self:
             r.check_in, r.check_out = None, None
             if not r.time_check_in or not r.time_check_out or not r.employee_id:
@@ -742,31 +770,16 @@ class EmployeeAttendanceV2(models.Model):
             check_in = attendance_ci[0] if attendance_ci else None
             check_out = attendance_co[-1] if attendance_co else None
 
-            in_outs = self.env['word.slip'].sudo().search([
-                ('from_date', '<=', r.date),
-                ('to_date', '>=', r.date),
-                ('type.date_and_time', '=', 'time'),
-                ('word_slip.status', '=', 'done')
-            ])
-
-            in_outs = in_outs.filtered(
-                lambda x: (x.word_slip.employee_id and x.word_slip.employee_id.id == r.employee_id.id) or (
-                        x.word_slip.employee_ids and r.employee_id.id in x.word_slip.employee_ids.ids))
-
+            in_outs = self._get_time_word_slips_in_window(r.employee_id, r.time_check_in, r.time_check_out)
             for in_out in in_outs:
-                if in_out and in_out.time_to:
-                    ci = calculate_time(in_out.time_to, r.date, datetime.combine(r.date, time(0, 0, 0)))
-                    ci = ci - relativedelta(hours=7)
-                    if (r.time_check_in <= ci <= r.time_check_out and r.check_no_in and ci <= r.check_no_in
-                            and (not check_in or check_in > ci)):
-                        check_in = ci
+                ci, co = self._get_time_word_slip_points_utc(in_out)
+                if (ci and r.time_check_in <= ci <= r.time_check_out and r.check_no_in and ci <= r.check_no_in
+                        and (not check_in or check_in > ci)):
+                    check_in = ci
 
-                if in_out and in_out.time_from:
-                    co = calculate_time(in_out.time_from, r.date, datetime.combine(r.date, time(0, 0, 0)))
-                    co = co - relativedelta(hours=7)
-                    if (r.time_check_in <= co <= r.time_check_out and r.check_no_out and co > r.check_no_out
-                            and (not check_out or check_out < co)):
-                        check_out = co
+                if (co and r.time_check_in <= co <= r.time_check_out and r.check_no_out and co > r.check_no_out
+                        and (not check_out or check_out < co)):
+                    check_out = co
 
             r.check_in = check_in
             r.check_out = check_out

--- a/sonha_word_slip/models/form_word_slip.py
+++ b/sonha_word_slip/models/form_word_slip.py
@@ -184,8 +184,14 @@ class FormWordSlip(models.Model):
             if not line.from_date or not line.to_date:
                 continue
 
-            current = line.from_date
-            while current <= line.to_date:
+            recompute_from = line.from_date
+            recompute_to = line.to_date
+            if rec.type.date_and_time == 'time':
+                recompute_from -= timedelta(days=1)
+                recompute_to += timedelta(days=1)
+
+            current = recompute_from
+            while current <= recompute_to:
                 for emp in employees:
                     self.env['employee.attendance.v2'].sudo().recompute_for_employee(
                         emp,
@@ -208,8 +214,14 @@ class FormWordSlip(models.Model):
             if not line.from_date or not line.to_date:
                 continue
 
-            current = line.from_date
-            while current <= line.to_date:
+            recompute_from = line.from_date
+            recompute_to = line.to_date
+            if line.type.date_and_time == 'time':
+                recompute_from -= timedelta(days=1)
+                recompute_to += timedelta(days=1)
+
+            current = recompute_from
+            while current <= recompute_to:
                 for emp in employees:
                     self.env['employee.attendance.v2'].sudo().recompute_for_employee(
                         emp,


### PR DESCRIPTION
### Motivation
- Time-based word slip entries that specify hours could cross midnight and were not consistently considered when computing employee check-in/out times, causing missed or incorrect attendance adjustments.
- The attendance recompute logic needed UTC-aware conversion and a slightly expanded recompute window for time-based slips to ensure cross-day slips are applied.

### Description
- Added `_float_time_to_local_datetime` to convert float hour values into local `datetime` values with validation for negative or non-numeric inputs. 
- Implemented `_get_time_word_slip_points_utc` to derive UTC check-in and check-out points from a time-based word slip and normalize cross-midnight ranges. 
- Implemented `_get_time_word_slips_in_window` to search and filter time-based word slips that intersect a given UTC window and belong to the specified employee. 
- Replaced the previous inline float-time conversion and direct search logic in `_get_check_in_out` with the new UTC-aware functions so word slips are correctly considered when computing `check_in` and `check_out`. 
- Expanded the recompute range in `FormWordSlip._recompute_word_slip_for_record` and `job_word_slip_for_record_queue` by one day before and after for slips where `type.date_and_time == 'time'` so cross-midnight slips are included in attendance recomputations. 

### Testing
- Ran the module's attendance recompute flow on sample employee records that include time-based word slips spanning midnight and verified computed `check_in`/`check_out` values matched expected UTC-aware times. 
- Executed the background recompute job (`job_word_slip_for_record_queue`) over a date range including time-based slips and confirmed the recompute ran without errors. 
- Ran the existing automated test suite for the attendance/word slip module and observed no failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2768d9055c83228ae5fdc01300ed0c)