### PR TITLE
Use AND logic for advanced tree search tags

### DIFF
--- a/tree_view_advanced_search/static/src/js/list_renderer_search_bar.js
+++ b/tree_view_advanced_search/static/src/js/list_renderer_search_bar.js
@@ -43,17 +43,9 @@ patch(ListRenderer.prototype, {
         tags.forEach(tag => {
             inputValues.push(tag.textContent);
         });
-        var Domain =[]
-        if (inputValues.length>1) {
-            for (let input=0; input<inputValues.length; input++) {
-                if (input != inputValues.length-1){
-                    Domain.splice(input, 0, '|');
-                }
-                Domain.push([name, 'ilike', inputValues[input]])
-            }
-        }
-        else {
-            Domain.push([name, 'ilike', inputValues[0]])
+        const Domain = []
+        for (const inputValue of inputValues) {
+            Domain.push([name, 'ilike', inputValue])
         }
         return Domain;
     },
@@ -97,12 +89,6 @@ patch(ListRenderer.prototype, {
             }
             return true;
         });
-        if (found) {
-            const index = this.domain.indexOf("|");
-            if (index !== -1) {
-                this.domain.splice(index, 1);
-            }
-        }
         this.env.searchModel.clearQuery();
         this.env.searchModel.splitAndAddDomain(this.domain);
         tag.remove();


### PR DESCRIPTION
### Motivation
- Combine multiple text search tags on the same column with AND instead of OR so that adding tags like `abc` and `xyz` yields records matching both conditions.

### Description
- Modified `_getInputValueAndDomain` in `tree_view_advanced_search/static/src/js/list_renderer_search_bar.js` to push each tag as a separate `[field, 'ilike', value]` condition and removed the insertion and cleanup of the `'|'` OR operator in `removeTag`.

### Testing
- Ran `node --check tree_view_advanced_search/static/src/js/list_renderer_search_bar.js` and `git diff --check`, both succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a27b019e5c8832491719b27e1e2ad75)