### PR TITLE
Handle shift rest and overnight overtime overlap; strengthen overtime validations

### DIFF
--- a/sonha_word_slip/models/employee_attendance_v2.py
+++ b/sonha_word_slip/models/employee_attendance_v2.py
@@ -118,6 +118,64 @@ class EmployeeAttendanceV2(models.Model):
             shift_end += timedelta(days=1)
         return shift_start, shift_end
 
+    def _is_shift_overnight(self, record):
+        shift_start, shift_end = self._get_shift_interval_local(record)
+        return bool(shift_start and shift_end and shift_end.date() > shift_start.date())
+
+    def _get_shift_rest_interval_local(self, record):
+        if (
+                not record.shift
+                or not record.shift.from_rest
+                or not record.shift.to_rest
+                or not record.date
+                or self._is_shift_overnight(record)
+        ):
+            return None, None
+
+        shift_start, shift_end = self._get_shift_interval_local(record)
+        if not shift_start or not shift_end:
+            return None, None
+
+        rest_start_time = self._to_local_datetime(record.shift.from_rest).time()
+        rest_end_time = self._to_local_datetime(record.shift.to_rest).time()
+        rest_start = datetime.combine(record.date, rest_start_time)
+        rest_end = datetime.combine(record.date, rest_end_time)
+        if rest_end <= rest_start:
+            rest_end += timedelta(days=1)
+
+        if rest_start <= shift_start or rest_end >= shift_end:
+            return None, None
+        return rest_start, rest_end
+
+    def _get_shift_work_intervals_local(self, record):
+        shift_start, shift_end = self._get_shift_interval_local(record)
+        if not shift_start or not shift_end:
+            return []
+
+        rest_start, rest_end = self._get_shift_rest_interval_local(record)
+        if not rest_start or not rest_end:
+            return [(shift_start, shift_end)]
+
+        return [(shift_start, rest_start), (rest_end, shift_end)]
+
+    def _is_overtime_inside_shift_rest(self, record, line):
+        if not record or not line or record.shift.shift_ot:
+            return False
+        ot_start, ot_end = self._get_overtime_line_interval_local(line)
+        rest_start, rest_end = self._get_shift_rest_interval_local(record)
+        return bool(ot_start and ot_end and rest_start and rest_end and ot_start >= rest_start and ot_end <= rest_end)
+
+    def _get_overtime_work_overlap_hours(self, record, line):
+        ot_start, ot_end = self._get_overtime_line_interval_local(line)
+        if not ot_start or not ot_end:
+            return 0
+
+        total = 0
+        for work_start, work_end in self._get_shift_work_intervals_local(record):
+            overlap_start, overlap_end = self._intersect_interval(ot_start, ot_end, work_start, work_end)
+            total += self._duration_hours(overlap_start, overlap_end)
+        return total
+
     def _get_shift_split_utc(self, record):
         shift_start, shift_end = self._get_shift_interval_local(record)
         if not shift_start or not shift_end:
@@ -183,7 +241,11 @@ class EmployeeAttendanceV2(models.Model):
             if attendance.shift.shift_ot and overlap_hours:
                 key = (0, -overlap_hours, abs((ot_start - shift_start).total_seconds()))
             elif not attendance.shift.shift_ot:
-                if ot_end <= shift_start:
+                if self._is_overtime_inside_shift_rest(attendance, line):
+                    key = (0, 0, abs((ot_start - shift_start).total_seconds()))
+                elif overlap_hours:
+                    key = (0, -overlap_hours, abs((ot_start - shift_start).total_seconds()))
+                elif ot_end <= shift_start:
                     gap_hours = self._duration_hours(ot_end, shift_start)
                     priority = 1 if gap_hours <= self.MAX_OT_SHIFT_GAP_HOURS else 2 if line.date == attendance.date else 3
                     key = (priority, gap_hours, 0)
@@ -225,10 +287,10 @@ class EmployeeAttendanceV2(models.Model):
         if record.shift.shift_ot:
             return self._duration_hours(work_start, work_end)
 
-        shift_start, shift_end = self._get_shift_interval_local(record)
-        inside_start, inside_end = self._intersect_interval(work_start, work_end, shift_start, shift_end)
         total = self._duration_hours(work_start, work_end)
-        total -= self._duration_hours(inside_start, inside_end)
+        for shift_work_start, shift_work_end in self._get_shift_work_intervals_local(record):
+            inside_start, inside_end = self._intersect_interval(work_start, work_end, shift_work_start, shift_work_end)
+            total -= self._duration_hours(inside_start, inside_end)
         return max(total, 0)
 
     def _get_actual_compensatory_hours_for_overtime(self, overtime, employee):

--- a/sonha_word_slip/models/overtime_rel.py
+++ b/sonha_word_slip/models/overtime_rel.py
@@ -29,9 +29,8 @@ class OvertimeRel(models.Model):
                 if not owner or not owner.shift:
                     raise ValidationError("Không thể tạo bản ghi khi bạn chưa có ca làm việc")
                 if not owner.shift.shift_ot:
-                    shift_start, shift_end = Attendance._get_shift_interval_local(owner)
-                    overlap_start, overlap_end = Attendance._intersect_interval(ot_start, ot_end, shift_start, shift_end)
-                    if overlap_start and overlap_end:
+                    overlap_hours = Attendance._get_overtime_work_overlap_hours(owner, record)
+                    if overlap_hours:
                         raise ValidationError(
                             "Khoảng thời gian bạn đăng ký đã nằm trong thời gian làm việc của ca!")
 

--- a/sonha_word_slip/models/register_overtime_update.py
+++ b/sonha_word_slip/models/register_overtime_update.py
@@ -54,7 +54,7 @@ class RegisterOvertimeUpdate(models.Model):
     actual_compensatory_hours = fields.Text(string="Giờ nghỉ bù thực tế", default="{}")
 
     @api.constrains('date')
-    def _check_overtime_conflict(self):
+    def _check_overtime_required_fields(self):
         for r in self:
             if not r.date:
                 raise ValidationError("Dữ liệu ngày giờ không được để trống!")
@@ -91,7 +91,7 @@ class RegisterOvertimeUpdate(models.Model):
             record.all_times = "\n".join(times) if times else "Không có dữ liệu"
 
     @api.constrains('employee_id', 'employee_ids', 'date')
-    def _check_overtime_conflict(self):
+    def _check_overtime_duplicate_conflict(self):
         for record in self:
             # Lấy danh sách nhân viên của đơn đăng ký
             employee_list = record.employee_ids.ids


### PR DESCRIPTION
### Motivation
- Correct overtime ownership and validation when overtime intersects shift rest periods or spans overnight shifts, and ensure overtime requests include required fields and do not duplicate existing requests.

### Description
- Added helpers in `employee_attendance_v2.py`: `
_is_shift_overnight`, `
_get_shift_rest_interval_local`, `
_get_shift_work_intervals_local`, `
_is_overtime_inside_shift_rest`, and `
_get_overtime_work_overlap_hours` to compute rest/work intervals and overlaps accurately.
- Updated overtime ownership logic in `
_get_overtime_owner_record` to treat overtime located entirely inside a shift rest specially and to use overlap/gap heuristics with the new rest-aware overlap computation.
- Adjusted actual overtime calculation in `
_get_actual_overtime_hours_for_line` to subtract all shift work intervals (accounting for rest splits) rather than a single shift interval.
- In `overtime_rel.py` replaced the simple interval intersection check with a call to `
_get_overtime_work_overlap_hours` to validate that registered overtime does not fall within working time.
- In `register_overtime_update.py` renamed and refactored constraints: `
_check_overtime_required_fields` enforces required date/ time/ reason fields and `
_check_overtime_duplicate_conflict` detects duplicate overtime entries for the same employee and date.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a38fe81f62483229c6f68317dc315de)