### PR TITLE
Fix MDM API company line lookup

### DIFF
--- a/sonha_mdm/models/mdm_khach_hang.py
+++ b/sonha_mdm/models/mdm_khach_hang.py
@@ -397,8 +397,26 @@ class MDMKhachHang(models.Model):
 
         return records
 
-    def _prepare_api_payload(self, record, sync_type, line=None):
-        company = line.dvcs if line and line.dvcs else record.dvcs
+
+    def _normalize_api_company(self, company):
+        if not company:
+            return self.env['res.company']
+        if hasattr(company, 'ids'):
+            return company[:1]
+        domain = [('id', '=', company)] if isinstance(company, int) else [('company_code', '=', company)]
+        return self.env['res.company'].sudo().search(domain, limit=1)
+
+    def _get_api_line_by_company(self, record, company=None, line=None):
+        if line:
+            return line
+        company = self._normalize_api_company(company)
+        if not company:
+            return None
+        return record.bang_con_ids.filtered(lambda item: item.dvcs.id == company.id)[:1]
+
+    def _prepare_api_payload(self, record, sync_type, line=None, company=None):
+        line = self._get_api_line_by_company(record, company=company, line=line)
+        company = line.dvcs if line and line.dvcs else (False if company else record.dvcs)
         return {
             "cccd": record.cccd or None,
             "mst": record.mst or None,
@@ -465,25 +483,30 @@ class MDMKhachHang(models.Model):
         target = line or record
         target.with_context(skip_mdm_similarity=True, skip_mdm_api_sync=True).sudo().write(values)
 
-    def call_api_insert(self, record, line=None):
-        data = self._prepare_api_payload(record, 'insert', line=line)
+    def call_api_insert(self, record, line=None, company=None):
+        line = self._get_api_line_by_company(record, company=company, line=line)
+        data = self._prepare_api_payload(record, 'insert', line=line, company=company)
         success, message = self._call_api_khach_hang(data, "API RESPONSE:", "API ERROR:")
         self._mark_api_result(record, success, message, line=line)
         return success
 
-    def call_api_update(self, record):
-        data = self._prepare_api_payload(record, 'update')
+    def call_api_update(self, record, line=None, company=None):
+        line = self._get_api_line_by_company(record, company=company, line=line)
+        data = self._prepare_api_payload(record, 'update', line=line, company=company)
         success, message = self._call_api_khach_hang(data, "API RESPONSE:", "API ERROR:")
-        self._mark_api_result(record, success, message)
+        self._mark_api_result(record, success, message, line=line)
         return success
 
     @api.model
-    def cron_call_api_insert_all_khach_hang(self, limit=None):
+    def cron_call_api_insert_all_khach_hang(self, limit=None, company=None):
         records = self.search([], limit=limit)
         for record in records:
-            record.call_api_insert(record)
-            for line in record.bang_con_ids:
-                record.call_api_insert(record, line=line)
+            if company:
+                record.call_api_insert(record, company=company)
+            else:
+                record.call_api_insert(record)
+                for line in record.bang_con_ids:
+                    record.call_api_insert(record, line=line)
         return True
 
     def action_view_popup(self):

--- a/sonha_mdm/models/mdm_khach_hang_line.py
+++ b/sonha_mdm/models/mdm_khach_hang_line.py
@@ -17,10 +17,13 @@ class MDMKhachHangLine(models.Model):
     def create(self, vals_list):
         records = super().create(vals_list)
         for record in records:
-            record.khach_hang_id.call_api_insert(record.khach_hang_id, line=record)
+            if not self.env.context.get('skip_mdm_api_sync'):
+                record.khach_hang_id.call_api_insert(record.khach_hang_id, line=record)
         return records
 
-    def write(self, vals_list):
-        for r in self:
-            r.khach_hang_id.call_api_update(r.tong_hop_id)
-        return super().write(vals_list)
+    def write(self, vals):
+        res = super().write(vals)
+        if not self.env.context.get('skip_mdm_api_sync'):
+            for record in self:
+                record.khach_hang_id.call_api_update(record.khach_hang_id, line=record)
+        return res

--- a/sonha_mdm/models/mdm_tong_hop.py
+++ b/sonha_mdm/models/mdm_tong_hop.py
@@ -374,8 +374,26 @@ class MDMTongHop(models.Model):
         for r in self:
             self.create_write_action_data(r)
 
-    def _prepare_api_payload(self, record, sync_type, line=None):
-        company = line.dvcs if line and line.dvcs else record.dvcs
+
+    def _normalize_api_company(self, company):
+        if not company:
+            return self.env['res.company']
+        if hasattr(company, 'ids'):
+            return company[:1]
+        domain = [('id', '=', company)] if isinstance(company, int) else [('company_code', '=', company)]
+        return self.env['res.company'].sudo().search(domain, limit=1)
+
+    def _get_api_line_by_company(self, record, company=None, line=None):
+        if line:
+            return line
+        company = self._normalize_api_company(company)
+        if not company:
+            return None
+        return record.bang_con_ids.filtered(lambda item: item.dvcs.id == company.id)[:1]
+
+    def _prepare_api_payload(self, record, sync_type, line=None, company=None):
+        line = self._get_api_line_by_company(record, company=company, line=line)
+        company = line.dvcs if line and line.dvcs else (False if company else record.dvcs)
         return {'ma_chung_loai1': record.chung_loai1.ma or None,
                 'ten_chung_loai1': record.chung_loai1.ten or None,
                 'ma_chung_loai2': record.chung_loai2.ma or None,
@@ -431,25 +449,30 @@ class MDMTongHop(models.Model):
         target = line or record
         target.with_context(skip_mdm_similarity=True, skip_mdm_api_sync=True).sudo().write(values)
 
-    def call_api_insert(self, record, line=None):
-        data = self._prepare_api_payload(record, 'insert', line=line)
+    def call_api_insert(self, record, line=None, company=None):
+        line = self._get_api_line_by_company(record, company=company, line=line)
+        data = self._prepare_api_payload(record, 'insert', line=line, company=company)
         success, message = self._call_api_hang_hoa(data, "API RESPONSE:", "API ERROR:")
         self._mark_api_result(record, success, message, line=line)
         return success
 
-    def call_api_update(self, record):
-        data = self._prepare_api_payload(record, 'update')
+    def call_api_update(self, record, line=None, company=None):
+        line = self._get_api_line_by_company(record, company=company, line=line)
+        data = self._prepare_api_payload(record, 'update', line=line, company=company)
         success, message = self._call_api_hang_hoa(data, "API hàng hóa:", "API hàng hóa:")
-        self._mark_api_result(record, success, message)
+        self._mark_api_result(record, success, message, line=line)
         return success
 
     @api.model
-    def cron_call_api_insert_all_hang_hoa(self, limit=None):
+    def cron_call_api_insert_all_hang_hoa(self, limit=None, company=None):
         records = self.search([], limit=limit)
         for record in records:
-            record.call_api_insert(record)
-            for line in record.bang_con_ids:
-                record.call_api_insert(record, line=line)
+            if company:
+                record.call_api_insert(record, company=company)
+            else:
+                record.call_api_insert(record)
+                for line in record.bang_con_ids:
+                    record.call_api_insert(record, line=line)
         return True
 
     def write(self, vals):

--- a/sonha_mdm/models/mdm_tong_hop_line.py
+++ b/sonha_mdm/models/mdm_tong_hop_line.py
@@ -21,10 +21,13 @@ class MDMTongHopLine(models.Model):
     def create(self, vals_list):
         records = super().create(vals_list)
         for record in records:
-            record.tong_hop_id.call_api_insert(record.tong_hop_id, line=record)
+            if not self.env.context.get('skip_mdm_api_sync'):
+                record.tong_hop_id.call_api_insert(record.tong_hop_id, line=record)
         return records
 
-    def write(self, vals_list):
-        for r in self:
-            r.tong_hop_id.call_api_update(r.tong_hop_id)
-        return super().write(vals_list)
+    def write(self, vals):
+        res = super().write(vals)
+        if not self.env.context.get('skip_mdm_api_sync'):
+            for record in self:
+                record.tong_hop_id.call_api_update(record.tong_hop_id, line=record)
+        return res


### PR DESCRIPTION
### Motivation
- Khi gọi API hàng hóa và khách hàng với tham số `company`, payload phải dùng thông tin đơn vị từ dòng con (`bang_con_ids`) tương ứng, không lấy mặc định từ bản cha.
- Cần hỗ trợ gọi API theo company cụ thể (ví dụ cron hoặc gọi thủ công) và tránh vòng lặp sync khi tạo/cập nhật dòng con.

### Description
- Thêm helper ` _normalize_api_company` và `_get_api_line_by_company` để chuyển `company` (id, record hoặc code) sang dòng con phù hợp và ưu tiên dòng con khi có `company` hoặc `line`.
- Thay đổi `_prepare_api_payload` để nhận thêm tham số `company` và sử dụng `line.dvcs` (nếu có) làm nguồn `ma_dvcs`/`ten_dvcs` và `ma_dv`/`ma_khach` thay vì luôn lấy từ bản cha.
- Cập nhật `call_api_insert`/`call_api_update` để nhận `company` và tự lookup dòng con; cập nhật cron `cron_call_api_insert_all_hang_hoa` / `cron_call_api_insert_all_khach_hang` để có thể chạy cho một `company` cụ thể.
- Sửa logic tạo/ghi của các bảng con (`mdm_tong_hop_line`, `mdm_khach_hang_line`) để chỉ gọi sync API khi không có context `skip_mdm_api_sync` và để kết quả API được ghi vào dòng con (tránh sync đệ quy); đồng thời sửa lỗi write ở `mdm_khach_hang_line` (trước đó gọi nhầm `tong_hop_id`).

### Testing
- Ran `git diff --check` to verify no whitespace errors and the check passed.
- Compiled modified modules with `python3 -m py_compile sonha_mdm/models/mdm_tong_hop.py sonha_mdm/models/mdm_khach_hang.py sonha_mdm/models/mdm_tong_hop_line.py sonha_mdm/models/mdm_khach_hang_line.py` and compilation succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a477ab4eb9c832db96b772af5de757e)