### PR TITLE
Adjust MDM imports to append child lines for existing codes

### DIFF
--- a/sonha_mdm/models/mdm_khach_hang_import_wizard.py
+++ b/sonha_mdm/models/mdm_khach_hang_import_wizard.py
@@ -38,21 +38,6 @@ class MDMKhachHangImportWizard(models.TransientModel):
         return str(value).strip() or False
 
     @staticmethod
-    def _merge_non_empty_vals(existing_record, incoming_vals):
-        merged_vals = {}
-        for field_name, value in incoming_vals.items():
-            if value in (False, None, ''):
-                continue
-
-            existing_value = existing_record[field_name]
-            if hasattr(existing_value, 'id'):
-                existing_value = existing_value.id or False
-            if existing_value != value:
-                merged_vals[field_name] = value
-
-        return merged_vals
-
-    @staticmethod
     def _merge_non_empty_dict(base_vals, incoming_vals):
         merged_vals = dict(base_vals)
         for field_name, value in incoming_vals.items():
@@ -144,7 +129,7 @@ class MDMKhachHangImportWizard(models.TransientModel):
         line_model = self.env['mdm.khach.hang.line']
 
         imported = 0
-        updated = 0
+        existing_count = 0
         errors = []
 
         import_rows, company_codes, lookup_codes_by_model = self._read_import_rows(sheet)
@@ -184,12 +169,7 @@ class MDMKhachHangImportWizard(models.TransientModel):
                 existing = existing_by_ma.get(ma_mdm)
 
                 if existing:
-                    update_vals = self._merge_non_empty_vals(existing, vals)
-                    if existing.dvcs.id != company.id:
-                        update_vals['dvcs'] = company.id
-                    if update_vals:
-                        existing.with_context(**import_context).sudo().write(update_vals)
-                    updated += 1
+                    existing_count += 1
                 else:
                     current_create_vals = dict(vals, dvcs=company.id)
                     if ma_mdm in pending_create_vals_by_ma:
@@ -206,7 +186,7 @@ class MDMKhachHangImportWizard(models.TransientModel):
                 errors.append(_('Dòng %(row)s (Mã MDM: %(ma_mdm)s): %(error)s', row=row_data['row_index'], ma_mdm=ma_mdm or '-', error=str(exc)))
 
         if errors:
-            message = _('Import hoàn tất. Tạo mới: %(new)s, Cập nhật: %(updated)s', new=imported, updated=updated)
+            message = _('Import hoàn tất. Tạo mới: %(new)s, Mã MDM đã tồn tại: %(existing)s', new=imported, existing=existing_count)
             message = message + '\n' + '\n'.join(errors[:20])
             raise ValidationError(message)
 

--- a/sonha_mdm/models/mdm_tong_hop_import_wizard.py
+++ b/sonha_mdm/models/mdm_tong_hop_import_wizard.py
@@ -36,21 +36,6 @@ class MDMTongHopImportWizard(models.TransientModel):
         return str(value).strip() or False
 
     @staticmethod
-    def _merge_non_empty_vals(existing_record, incoming_vals):
-        merged_vals = {}
-        for field_name, value in incoming_vals.items():
-            if value in (False, None, ''):
-                continue
-
-            existing_value = existing_record[field_name]
-            if hasattr(existing_value, 'id'):
-                existing_value = existing_value.id or False
-            if existing_value != value:
-                merged_vals[field_name] = value
-
-        return merged_vals
-
-    @staticmethod
     def _merge_non_empty_dict(base_vals, incoming_vals):
         merged_vals = dict(base_vals)
         for field_name, value in incoming_vals.items():
@@ -143,7 +128,7 @@ class MDMTongHopImportWizard(models.TransientModel):
         line_model = self.env['mdm.tong.hop.line']
 
         imported = 0
-        updated = 0
+        existing_count = 0
         errors = []
 
         import_rows, company_codes, lookup_codes_by_model = self._read_import_rows(sheet)
@@ -183,12 +168,7 @@ class MDMTongHopImportWizard(models.TransientModel):
                 existing = existing_by_ma.get(ma_mdm)
 
                 if existing:
-                    update_vals = self._merge_non_empty_vals(existing, vals)
-                    if existing.dvcs.id != company.id:
-                        update_vals['dvcs'] = company.id
-                    if update_vals:
-                        existing.with_context(**import_context).sudo().write(update_vals)
-                    updated += 1
+                    existing_count += 1
                 else:
                     current_create_vals = dict(vals, dvcs=company.id)
                     if ma_mdm in pending_create_vals_by_ma:
@@ -205,7 +185,7 @@ class MDMTongHopImportWizard(models.TransientModel):
                 errors.append(_('Dòng %(row)s (Mã MDM: %(ma_mdm)s): %(error)s', row=row_data['row_index'], ma_mdm=ma_mdm or '-', error=str(exc)))
 
         if errors:
-            message = _('Import hoàn tất. Tạo mới: %(new)s, Cập nhật: %(updated)s', new=imported, updated=updated)
+            message = _('Import hoàn tất. Tạo mới: %(new)s, Mã MDM đã tồn tại: %(existing)s', new=imported, existing=existing_count)
             message = message + '\n' + '\n'.join(errors[:20])
             raise ValidationError(message)
 


### PR DESCRIPTION
### Motivation
- Change import behavior so that when an existing `ma` (MDM code) is found during import, the importer no longer updates the parent record but always appends a child line for that `ma` so unit-specific rows are preserved.

### Description
- For both `mdm.tong.hop` and `mdm.khach.hang` import wizards (`sonha_mdm/models/mdm_tong_hop_import_wizard.py` and `sonha_mdm/models/mdm_khach_hang_import_wizard.py`) removed the logic that merged non-empty incoming values into existing parent records and stopped performing `write` on existing parents.  
- Replaced the `updated` counter with `existing_count` to reflect that existing codes are counted but not modified.  
- Removed the helper `_merge_non_empty_vals` as it is no longer used.  
- Kept the creation of child rows and ensured `mdm.tong.hop.line` and `mdm.khach.hang.line` entries are created for every imported row (including those whose parent `ma` already exists), and updated the import summary message to use `Mã MDM đã tồn tại` instead of `Cập nhật`.

### Testing
- Ran `python3 -m compileall sonha_mdm/models/mdm_tong_hop_import_wizard.py sonha_mdm/models/mdm_khach_hang_import_wizard.py`, which completed successfully.  
- Ran `git diff --check` to validate whitespace/format issues, which reported no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4f1bf3500c832d8d63146efaed8937)