### PR TITLE
Replace customer import plan with CCCD

### DIFF
--- a/sonha_mdm/models/mdm_khach_hang_import_wizard.py
+++ b/sonha_mdm/models/mdm_khach_hang_import_wizard.py
@@ -16,7 +16,6 @@ class MDMKhachHangImportWizard(models.TransientModel):
         ('quan_huyen_cu', 'quan.huyen.cu', 6, 'Quận/huyện cũ'),
         ('tinh_cu', 'tinh.cu', 7, 'Tỉnh cũ'),
         ('dat_nuoc', 'mdm.quoc.gia', 8, 'Quốc gia'),
-        ('plan', 'mdm.plan', 11, 'Plant'),
         ('ma_cn', 'mdm.chi.nhanh', 12, 'CN/NPP'),
         ('nhom_khach', 'mdm.nhom.khach', 13, 'Nhóm KH_NCC'),
         ('ten_salesman', 'mdm.saleman', 14, 'Mã_salesman'),
@@ -109,6 +108,7 @@ class MDMKhachHangImportWizard(models.TransientModel):
             'dia_chi_khach': row_values[4],
             'so_dien_thoai': row_values[9],
             'mst': row_values[10],
+            'cccd': row_values[11],
             'vung': row_values[15],
         }
 


### PR DESCRIPTION
### Motivation
- Thay thế cột Plant/`plan` trong quá trình import khách hàng để lưu giá trị `cccd` thay cho `plan` khi tạo bản ghi khách hàng.

### Description
- Xóa mục `('plan', 'mdm.plan', 11, 'Plant')` khỏi `LOOKUP_FIELDS` và thêm mapping `"cccd": row_values[11]` vào `vals` trong `sonha_mdm/models/mdm_khach_hang_import_wizard.py`.

### Testing
- Chạy `python3 -m py_compile sonha_mdm/models/mdm_khach_hang_import_wizard.py` và `git diff --check`, cả hai lệnh đều thực thi thành công.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4f1daa5210832db4f680bec0c5d9b4)