### PR TITLE
Refine attendance matching windows and neighbor bounds in EmployeeAttendanceV2

### DIFF
--- a/sonha_word_slip/models/employee_attendance_v2.py
+++ b/sonha_word_slip/models/employee_attendance_v2.py
@@ -139,8 +139,20 @@ class EmployeeAttendanceV2(models.Model):
         actual_end = preferred['actual_end']
         split_local = preferred['split']
 
-        check_in_fallback_start = datetime.combine(actual_start.date(), time.min)
-        check_out_fallback_end = datetime.combine(actual_end.date(), time.max)
+        preferred_check_in_start, _preferred_check_in_end = preferred['check_in']
+        _preferred_check_out_start, preferred_check_out_end = preferred['check_out']
+
+        if preferred_check_in_start.date() < actual_start.date():
+            check_in_fallback_start = preferred_check_in_start
+        else:
+            check_in_fallback_start = datetime.combine(actual_start.date(), time.min)
+
+        if preferred_check_out_end.date() > actual_end.date():
+            check_out_fallback_end = preferred_check_out_end
+        else:
+            check_out_fallback_end = datetime.combine(actual_end.date(), time.max)
+        previous_check_out_bound = None
+        next_check_in_bound = None
 
         neighbor_records = self.sudo().search([
             ('employee_id', '=', record.employee_id.id),
@@ -156,17 +168,32 @@ class EmployeeAttendanceV2(models.Model):
 
             if neighbor_check_out:
                 neighbor_co_start, neighbor_co_end = neighbor_check_out
-                if neighbor_co_end.date() == actual_start.date() and neighbor_co_end <= split_local:
+                if neighbor_co_end <= preferred_check_in_start:
+                    previous_check_out_bound = max(
+                        previous_check_out_bound or neighbor_co_end,
+                        neighbor_co_end
+                    )
+                elif check_in_fallback_start <= neighbor_co_end <= split_local:
                     check_in_fallback_start = max(check_in_fallback_start, neighbor_co_end)
-                elif neighbor_co_start.date() == actual_start.date() and neighbor_co_start < split_local:
+                elif neighbor_co_start < split_local and neighbor_co_end >= check_in_fallback_start:
                     check_in_fallback_start = max(check_in_fallback_start, min(neighbor_co_end, split_local))
 
             if neighbor_check_in:
                 neighbor_ci_start, neighbor_ci_end = neighbor_check_in
-                if neighbor_ci_start.date() == actual_end.date() and neighbor_ci_start >= split_local:
+                if neighbor_ci_start >= preferred_check_out_end:
+                    next_check_in_bound = min(
+                        next_check_in_bound or neighbor_ci_start,
+                        neighbor_ci_start
+                    )
+                elif split_local <= neighbor_ci_start <= check_out_fallback_end:
                     check_out_fallback_end = min(check_out_fallback_end, neighbor_ci_start)
-                elif neighbor_ci_end.date() == actual_end.date() and neighbor_ci_end > split_local:
+                elif neighbor_ci_start <= check_out_fallback_end and neighbor_ci_end > split_local:
                     check_out_fallback_end = min(check_out_fallback_end, max(neighbor_ci_start, split_local))
+
+        if previous_check_out_bound:
+            check_in_fallback_start = min(check_in_fallback_start, previous_check_out_bound)
+        if next_check_in_bound:
+            check_out_fallback_end = max(check_out_fallback_end, next_check_in_bound)
 
         return {
             'check_in_preferred': (self._to_utc_datetime(preferred['check_in'][0]),


### PR DESCRIPTION
### Motivation
- Make raw attendance CI/CO window computation more robust to preferred windows that cross date boundaries and to neighboring day records.
- Ensure fallback CI/CO bounds account for neighbor records both before and after the current interval rather than only using day min/max.

### Description
- Change `_get_attendance_priority_windows_utc` to derive initial fallback bounds from the preferred `check_in`/`check_out` edges instead of always using `time.min`/`time.max` for the record dates. 
- Introduce `previous_check_out_bound` and `next_check_in_bound` to capture neighbor records that lie entirely before the preferred check-in or after the preferred check-out and incorporate them into fallback bounds. 
- Replace date-based neighbor comparisons with direct datetime comparisons against `preferred_check_in_start`, `preferred_check_out_end`, and `split_local`, and tighten overlap conditions when updating fallback starts/ends. 
- Preserve conversion of final preferred and fallback windows to UTC via `_to_utc_datetime` for downstream matching.

### Testing
- Ran the module's attendance matching unit tests including `test_attendance_matching` and the affected `EmployeeAttendanceV2` cases, and they completed successfully. 
- Ran the repository test suite (`pytest`) and static checks, and no regressions were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a686b116edc8322940b1283029075ee)