### PR TITLE
Fix attendance v2 sync SQL correlation

### DIFF
--- a/sonha_word_slip/models/employee_attendance_v2.py
+++ b/sonha_word_slip/models/employee_attendance_v2.py
@@ -1840,26 +1840,24 @@ class EmployeeAttendanceV2(models.Model):
 
                 UPDATE employee_attendance_v2 AS v2
                 SET
-                    check_in = ci.check_in,
-                    check_out = co.check_out
-                FROM LATERAL (
-                    SELECT MIN(mda.attendance_time) AS check_in
-                    FROM master_data_attendance AS mda
-                    WHERE mda.employee_id = v2.employee_id
-                      AND mda.attendance_time >= v2.time_check_in
-                      AND mda.attendance_time <= v2.time_check_out
-                      AND v2.check_no_in IS NOT NULL
-                      AND mda.attendance_time <= v2.check_no_in
-                ) AS ci,
-                LATERAL (
-                    SELECT MAX(mda.attendance_time) AS check_out
-                    FROM master_data_attendance AS mda
-                    WHERE mda.employee_id = v2.employee_id
-                      AND mda.attendance_time >= v2.time_check_in
-                      AND mda.attendance_time <= v2.time_check_out
-                      AND v2.check_no_out IS NOT NULL
-                      AND mda.attendance_time >= v2.check_no_out
-                ) AS co
+                    check_in = (
+                        SELECT MIN(mda.attendance_time)
+                        FROM master_data_attendance AS mda
+                        WHERE mda.employee_id = v2.employee_id
+                          AND mda.attendance_time >= v2.time_check_in
+                          AND mda.attendance_time <= v2.time_check_out
+                          AND v2.check_no_in IS NOT NULL
+                          AND mda.attendance_time <= v2.check_no_in
+                    ),
+                    check_out = (
+                        SELECT MAX(mda.attendance_time)
+                        FROM master_data_attendance AS mda
+                        WHERE mda.employee_id = v2.employee_id
+                          AND mda.attendance_time >= v2.time_check_in
+                          AND mda.attendance_time <= v2.time_check_out
+                          AND v2.check_no_out IS NOT NULL
+                          AND mda.attendance_time >= v2.check_no_out
+                    )
                 WHERE v2.employee_id = p_employee_id
                   AND v2.time_check_in IS NOT NULL
                   AND v2.time_check_out IS NOT NULL


### PR DESCRIPTION
### Motivation
- Inserting/updating raw attendance rows caused a PostgreSQL error: invalid reference to FROM-clause entry for table "v2" when the function `sync_employee_attendance_v2_check_in_out` used `UPDATE ... FROM LATERAL` that referenced the target alias `v2` from the lateral subselects. 
- The change replaces the problematic lateral usage with correlated scalar subqueries to allow safe references to `v2` inside the `SET` clause.

### Description
- Replaced the `UPDATE ... FROM LATERAL` query in `sync_employee_attendance_v2_check_in_out` with correlated scalar subqueries for `check_in` and `check_out` inside the `SET` clause. 
- Preserved the original filtering logic (employee/time windows and `check_no_in`/`check_no_out` checks) and retained trigger function `trg_sync_employee_attendance_v2_check_in_out` behavior. 
- Modified file: `sonha_word_slip/models/employee_attendance_v2.py` (SQL in `init` method).

### Testing
- Ran `python -m py_compile sonha_word_slip/models/employee_attendance_v2.py` and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a700e0c6124832db106808e5c8ee1a9)