### PR TITLE
Fix attendance v2 check-in/out sync SQL function

### DIFF
--- a/sonha_word_slip/models/employee_attendance_v2.py
+++ b/sonha_word_slip/models/employee_attendance_v2.py
@@ -1821,13 +1821,18 @@ class EmployeeAttendanceV2(models.Model):
     #
     #     return base64.b64encode(output.read())
 
-    def init(self):
+    def _setup_check_in_out_sync_sql(self):
         self.env.cr.execute("""
             CREATE INDEX IF NOT EXISTS master_data_attendance_employee_time_idx
                 ON master_data_attendance (employee_id, attendance_time);
 
             CREATE INDEX IF NOT EXISTS employee_attendance_v2_employee_date_idx
                 ON employee_attendance_v2 (employee_id, date);
+
+            DROP FUNCTION IF EXISTS sync_employee_attendance_v2_check_in_out(
+                integer,
+                timestamp without time zone
+            ) CASCADE;
 
             CREATE OR REPLACE FUNCTION sync_employee_attendance_v2_check_in_out(
                 p_employee_id integer,
@@ -1895,3 +1900,11 @@ class EmployeeAttendanceV2(models.Model):
                 FOR EACH ROW
                 EXECUTE FUNCTION trg_sync_employee_attendance_v2_check_in_out();
         """)
+
+    def init(self):
+        self._setup_check_in_out_sync_sql()
+
+    def _register_hook(self):
+        res = super()._register_hook()
+        self._setup_check_in_out_sync_sql()
+        return res


### PR DESCRIPTION
### Motivation
- Fix PostgreSQL error "invalid reference to FROM-clause entry for table \"v2\"" caused by a stale DB function that used an invalid `FROM LATERAL` pattern and ensure the corrected sync function is reliably installed on module init and registry reload.

### Description
- Add `DROP FUNCTION IF EXISTS sync_employee_attendance_v2_check_in_out(integer, timestamp without time zone) CASCADE;` before creating the function to remove stale definitions that can reference `v2` incorrectly.
- Extract the SQL that creates indexes, the sync function and trigger into a helper method `def _setup_check_in_out_sync_sql(self):` so it can be invoked in multiple lifecycle points.
- Call the helper from `init` and from `_register_hook` so the corrected function and trigger are installed both on module initialization and when the Odoo registry is loaded.
- Retain the `UPDATE employee_attendance_v2 AS v2` implementation using correlated subqueries in `SET` to avoid `LATERAL`/scope issues.

### Testing
- Ran `python3 -m py_compile sonha_word_slip/models/employee_attendance_v2.py` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a700f04e038832da1ba69222668d501)