### PR TITLE
Fix attendance v2 recompute chain

### DIFF
--- a/hr_zk_attendance/models/master_data_attendance.py
+++ b/hr_zk_attendance/models/master_data_attendance.py
@@ -2,6 +2,11 @@ from odoo import models, fields, api
 from datetime import timedelta
 
 
+def _attendance_v2_date_window(attendance_time):
+    local_date = (attendance_time + timedelta(hours=7)).date()
+    return local_date - timedelta(days=1), local_date + timedelta(days=1)
+
+
 class MasterDataAttendance(models.Model):
     _name = 'master.data.attendance'
     _description = 'Master Data Attendance'
@@ -24,33 +29,37 @@ class MasterDataAttendance(models.Model):
         for r in self:
             r.department_id = r.employee_id.department_id.id if r.employee_id.department_id.id else None
 
-    def create(self, vals):
-        rec = super().create(vals)
-        if rec.employee_id and rec.attendance_time:
-            self.env['employee.attendance.v2'].sudo().recompute_for_employee(
-                rec.employee_id,
-                (rec.attendance_time + timedelta(hours=7)).date() - timedelta(days=1),
-                (rec.attendance_time + timedelta(hours=7)).date() + timedelta(days=1)
-            )
-        return rec
+    @api.model_create_multi
+    def create(self, vals_list):
+        recs = super().create(vals_list)
+        recs._recompute_attendance_v2_for_punches()
+        return recs
 
     def write(self, vals):
+        old_punches = self._get_attendance_v2_recompute_payload()
         res = super().write(vals)
-        for rec in self:
-            if rec.employee_id:
-                self.env['employee.attendance.v2'].sudo().recompute_for_employee(
-                    rec.employee_id,
-                    (rec.attendance_time + timedelta(hours=7)).date() - timedelta(days=1),
-                    (rec.attendance_time + timedelta(hours=7)).date() + timedelta(days=1)
-                )
+        self._recompute_attendance_v2_payload(old_punches)
+        self._recompute_attendance_v2_for_punches()
         return res
 
     def unlink(self):
+        old_punches = self._get_attendance_v2_recompute_payload()
+        res = super().unlink()
+        self._recompute_attendance_v2_payload(old_punches)
+        return res
+
+    def _get_attendance_v2_recompute_payload(self):
+        payload = []
         for rec in self:
             if rec.employee_id and rec.attendance_time:
-                self.env['employee.attendance.v2'].sudo().recompute_for_employee(
-                    rec.employee_id,
-                    (rec.attendance_time + timedelta(hours=7)).date() - timedelta(days=1),
-                    (rec.attendance_time + timedelta(hours=7)).date() + timedelta(days=1)
-                )
-        return super().unlink()
+                payload.append((rec.employee_id.id, rec.attendance_time))
+        return payload
+
+    def _recompute_attendance_v2_for_punches(self):
+        self._recompute_attendance_v2_payload(self._get_attendance_v2_recompute_payload())
+
+    def _recompute_attendance_v2_payload(self, payload):
+        attendance_v2 = self.env['employee.attendance.v2'].sudo()
+        for employee_id, attendance_time in payload:
+            date_from, date_to = _attendance_v2_date_window(attendance_time)
+            attendance_v2.recompute_for_employee(employee_id, date_from, date_to)

--- a/sonha_word_slip/models/employee_attendance_v2.py
+++ b/sonha_word_slip/models/employee_attendance_v2.py
@@ -456,7 +456,7 @@ class EmployeeAttendanceV2(models.Model):
             if r.shift and r.shift.is_office_hour and (weekday == 6 or (weekday == 5 and week_number % 2 == 1)):
                 r.work_calendar = False
 
-    @api.depends('shift')
+    @api.depends('shift', 'work_day')
     def get_work_hc_sp(self):
         for r in self:
             r.work_sp = 0
@@ -466,7 +466,7 @@ class EmployeeAttendanceV2(models.Model):
             else:
                 r.work_hc = r.work_day
 
-    @api.depends('shift')
+    @api.depends('shift', 'work_day')
     def get_shift(self):
         for r in self:
             # Reset giá trị mặc định
@@ -991,7 +991,7 @@ class EmployeeAttendanceV2(models.Model):
             r.check_out = check_out
 
     # Lấy thông tin xem nhân viên có check-in hay check-out hay không
-    @api.depends('shift', 'check_out', 'check_in')
+    @api.depends('shift', 'check_out', 'check_in', 'leave', 'compensatory', 'vacation')
     def _get_attendance(self):
         for r in self:
             if (not r.check_in and not r.check_out) or (r.check_in and r.check_out):
@@ -1008,7 +1008,7 @@ class EmployeeAttendanceV2(models.Model):
                 r.note = None
 
     # Lấy thông tin số phút nhân viên đi muộn hoặc về sớm
-    @api.depends('check_out', 'check_in', 'employee_id')
+    @api.depends('check_out', 'check_in', 'employee_id', 'shift', 'date', 'leave', 'compensatory', 'vacation')
     def _get_minute_late_early(self):
         for r in self:
             r.minutes_late, r.minutes_early = 0, 0
@@ -1042,7 +1042,7 @@ class EmployeeAttendanceV2(models.Model):
                 r.minutes_late = 0
 
     # Lấy thông tin ngày công của nhân viên
-    @api.depends('check_in', 'check_out', 'shift')
+    @api.depends('check_in', 'check_out', 'shift', 'date', 'employee_id', 'leave', 'compensatory')
     def _get_work_day(self):
         for r in self:
             weekday = r.date.weekday()
@@ -1121,7 +1121,7 @@ class EmployeeAttendanceV2(models.Model):
                 r.weekday = None
 
     # tính màu cho danh sách
-    @api.depends('date', 'check_in', 'check_out', 'minutes_late', 'minutes_early')
+    @api.depends('date', 'check_in', 'check_out', 'minutes_late', 'minutes_early', 'public_leave', 'work_day', 'over_time', 'shift', 'employee_id')
     def _compute_color(self):
         today = date.today()
         for r in self:
@@ -1277,6 +1277,45 @@ class EmployeeAttendanceV2(models.Model):
                 application_id=0,
             )
 
+    def _recompute_attendance_v2_fields(self):
+        """Recompute stored fields in dependency order without bypassing ORM dependencies.
+
+        Raw SQL updates of check_in/check_out do not invalidate Odoo's stored computed
+        fields, so every field depending on them (and fields depending on those fields)
+        can become stale. This helper keeps all recalculation inside ORM compute
+        methods and explicitly walks the domino chain in a stable order for batch jobs
+        and attendance punch changes.
+        """
+        records = self.sudo()
+        if not records:
+            return True
+
+        records.get_department()
+        records._compute_weekday()
+        records._get_month_year()
+        records._get_shift_employee()
+        records._get_duration()
+        records.get_work_calendar()
+        records._get_time_in_out()
+        records._check_no_in_out()
+        records._get_check_in_out()
+        records.get_hours_reinforcement()
+        records._get_work_day()
+        records._get_time_off()
+        records._get_attendance()
+        records._get_minute_late_early()
+        records._get_work_day()
+        records.get_hours_reinforcement()
+        records._get_sunday_work()
+        records.get_work_hc_sp()
+        records.get_shift()
+        records.get_times_late()
+        records._get_actual_work()
+        records._get_forgot_time()
+        records._get_work_eat()
+        records._compute_color()
+        return True
+
     def recompute_for_employee(self, employee, date_from=None, date_to=None):
         """Helper: gọi từ model khác (vd word.slip.write/create/unlink) để
            recompute các employee.attendance liên quan.
@@ -1293,19 +1332,7 @@ class EmployeeAttendanceV2(models.Model):
             domain.append(('date', '<=', fields.Date.to_date(date_to)))
         list_recs = self.search(domain)
         if list_recs:
-            for recs in list_recs:
-            # ghi lại để force recompute store fields
-                recs.sudo().write({'date': recs.date})  # ghi lại trường date để kích hoạt recompute store
-                # hoặc gọi recompute cụ thể
-                recs._get_shift_employee()
-                recs._get_time_off()
-                recs._get_time_in_out()
-                recs._check_no_in_out()
-                recs._get_check_in_out()
-                recs.get_hours_reinforcement()
-                recs._get_minute_late_early()
-                recs._get_work_day()
-                recs.get_department()
+            list_recs.sudo()._recompute_attendance_v2_fields()
 
         overtime_domain = []
         if date_from:
@@ -1340,7 +1367,7 @@ class EmployeeAttendanceV2(models.Model):
         ids = [r[0] for r in self.env.cr.fetchall()]
         recs = self.env['employee.attendance.v2'].browse(ids)
         if recs:
-            recs.sudo()._get_time_in_out()
+            recs.sudo()._recompute_attendance_v2_fields()
 
     def action_export_excel(self, ids):
 
@@ -1822,6 +1849,14 @@ class EmployeeAttendanceV2(models.Model):
     #     return base64.b64encode(output.read())
 
     def _setup_check_in_out_sync_sql(self):
+        """Keep supporting indexes and remove the legacy SQL sync trigger.
+
+        The old trigger updated check_in/check_out directly in PostgreSQL. That
+        bypassed Odoo ORM invalidation, so stored computed fields depending on
+        check_in/check_out were not recomputed. Attendance changes are now synced
+        through recompute_for_employee(), which uses ORM compute methods for the
+        full dependency chain.
+        """
         self.env.cr.execute("""
             CREATE INDEX IF NOT EXISTS master_data_attendance_employee_time_idx
                 ON master_data_attendance (employee_id, attendance_time);
@@ -1829,76 +1864,16 @@ class EmployeeAttendanceV2(models.Model):
             CREATE INDEX IF NOT EXISTS employee_attendance_v2_employee_date_idx
                 ON employee_attendance_v2 (employee_id, date);
 
+            DROP TRIGGER IF EXISTS master_data_attendance_sync_v2_check_in_out
+                ON master_data_attendance;
+
+            DROP FUNCTION IF EXISTS trg_sync_employee_attendance_v2_check_in_out()
+                CASCADE;
+
             DROP FUNCTION IF EXISTS sync_employee_attendance_v2_check_in_out(
                 integer,
                 timestamp without time zone
             ) CASCADE;
-
-            CREATE OR REPLACE FUNCTION sync_employee_attendance_v2_check_in_out(
-                p_employee_id integer,
-                p_attendance_time timestamp without time zone
-            ) RETURNS void AS $$
-            BEGIN
-                IF p_employee_id IS NULL OR p_attendance_time IS NULL THEN
-                    RETURN;
-                END IF;
-
-                UPDATE employee_attendance_v2 AS v2
-                SET
-                    check_in = (
-                        SELECT MIN(mda.attendance_time)
-                        FROM master_data_attendance AS mda
-                        WHERE mda.employee_id = v2.employee_id
-                          AND mda.attendance_time >= v2.time_check_in
-                          AND mda.attendance_time <= v2.time_check_out
-                          AND v2.check_no_in IS NOT NULL
-                          AND mda.attendance_time <= v2.check_no_in
-                    ),
-                    check_out = (
-                        SELECT MAX(mda.attendance_time)
-                        FROM master_data_attendance AS mda
-                        WHERE mda.employee_id = v2.employee_id
-                          AND mda.attendance_time >= v2.time_check_in
-                          AND mda.attendance_time <= v2.time_check_out
-                          AND v2.check_no_out IS NOT NULL
-                          AND mda.attendance_time >= v2.check_no_out
-                    )
-                WHERE v2.employee_id = p_employee_id
-                  AND v2.time_check_in IS NOT NULL
-                  AND v2.time_check_out IS NOT NULL
-                  AND v2.date BETWEEN ((p_attendance_time + interval '7 hours')::date - 1)
-                                  AND ((p_attendance_time + interval '7 hours')::date + 1)
-                  AND p_attendance_time BETWEEN (v2.time_check_in - interval '1 day')
-                                           AND (v2.time_check_out + interval '1 day');
-            END;
-            $$ LANGUAGE plpgsql;
-
-            CREATE OR REPLACE FUNCTION trg_sync_employee_attendance_v2_check_in_out()
-            RETURNS trigger AS $$
-            BEGIN
-                IF TG_OP IN ('INSERT', 'UPDATE') THEN
-                    PERFORM sync_employee_attendance_v2_check_in_out(NEW.employee_id, NEW.attendance_time);
-                END IF;
-
-                IF TG_OP IN ('UPDATE', 'DELETE') THEN
-                    PERFORM sync_employee_attendance_v2_check_in_out(OLD.employee_id, OLD.attendance_time);
-                END IF;
-
-                IF TG_OP = 'DELETE' THEN
-                    RETURN OLD;
-                END IF;
-                RETURN NEW;
-            END;
-            $$ LANGUAGE plpgsql;
-
-            DROP TRIGGER IF EXISTS master_data_attendance_sync_v2_check_in_out
-                ON master_data_attendance;
-
-            CREATE TRIGGER master_data_attendance_sync_v2_check_in_out
-                AFTER INSERT OR UPDATE OF employee_id, attendance_time OR DELETE
-                ON master_data_attendance
-                FOR EACH ROW
-                EXECUTE FUNCTION trg_sync_employee_attendance_v2_check_in_out();
         """)
 
     def init(self):


### PR DESCRIPTION
### Motivation
- The existing PostgreSQL trigger/function updated `employee_attendance_v2.check_in` and `check_out` directly in SQL which bypassed Odoo ORM invalidation and left downstream stored computed fields stale, creating a "domino" of fields not being recomputed.
- We need a safe recompute path that uses ORM compute methods in the correct dependency order so all stored fields depending on check-in/check-out are updated reliably.

### Description
- Remove the legacy SQL sync trigger and function that updated `check_in`/`check_out` and keep only supporting indexes in `EmployeeAttendanceV2._setup_check_in_out_sync_sql()` to avoid bypassing ORM invalidation (file: `sonha_word_slip/models/employee_attendance_v2.py`).
- Add `_recompute_attendance_v2_fields()` helper that walks the recompute chain inside ORM compute methods in a stable order to refresh all stored fields that depend (directly or transitively) on check-in/check-out (file: `sonha_word_slip/models/employee_attendance_v2.py`).
- Update `recompute_for_employee()` and `recompute_for_overtime()` to invoke the new helper so recompute requests refresh the full dependency chain (file: `sonha_word_slip/models/employee_attendance_v2.py`).
- Adjust compute dependencies (`@api.depends`) for various fields so Odoo knows the correct dependency graph (several compute methods in `employee_attendance_v2.py`).
- Change `master.data.attendance` create/write/unlink flows to collect affected punch payloads and call recompute via ORM for the relevant employee/date windows, ensuring both old and new punch windows are recomputed when punches change (file: `hr_zk_attendance/models/master_data_attendance.py`).

### Testing
- `git diff --check` was executed and returned clean results (success).
- `python3 -m py_compile sonha_word_slip/models/employee_attendance_v2.py hr_zk_attendance/models/master_data_attendance.py` was run and both files compiled successfully (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a70105ce464832dbff5a54e93b9416a)