### PR TITLE
Add compatibility reCAPTCHA fields to res.config.settings

### DIFF
--- a/muk_web_theme/__manifest__.py
+++ b/muk_web_theme/__manifest__.py
@@ -5,7 +5,7 @@
         This module offers a mobile compatible design for Odoo Community. 
         Furthermore it allows the user to define some design preferences.
     ''',
-    'version': '17.0.1.2.1',
+    'version': '17.0.1.2.2',
     'category': 'Themes/Backend', 
     'license': 'LGPL-3', 
     'author': 'MuK IT',

--- a/muk_web_theme/models/res_config_settings.py
+++ b/muk_web_theme/models/res_config_settings.py
@@ -51,6 +51,26 @@ class ResConfigSettings(models.TransientModel):
     theme_color_appbar_background = fields.Char(
         string='AppsBar Background Color'
     )
+
+    # Compatibility fields for settings views left by recaptcha modules.
+    # Some databases can still contain inherited settings views referencing
+    # these fields even when the original module that defined them is no
+    # longer loaded, which breaks the Settings app before it can render.
+    recaptcha_public_key = fields.Char(
+        string='reCAPTCHA Site Key',
+        config_parameter='recaptcha_public_key'
+    )
+
+    recaptcha_private_key = fields.Char(
+        string='reCAPTCHA Secret Key',
+        config_parameter='recaptcha_private_key'
+    )
+
+    recaptcha_min_score = fields.Float(
+        string='reCAPTCHA Minimum Score',
+        config_parameter='recaptcha_min_score',
+        default=0.5
+    )
     
     #----------------------------------------------------------
     # Helper


### PR DESCRIPTION
### Motivation
- Opening the Settings app failed with an Owl lifecycle error because some inherited settings views reference `recaptcha_public_key` and related fields that may be missing when the originating recaptcha module is not installed. 
- Provide compatibility on `res.config.settings` so legacy/inherited views can render without crashing the Settings UI.

### Description
- Added compatibility fields `recaptcha_public_key`, `recaptcha_private_key`, and `recaptcha_min_score` to the `res.config.settings` transient model with appropriate `config_parameter` bindings and a default for `recaptcha_min_score`.
- Updated `muk_web_theme` module `version` from `17.0.1.2.1` to `17.0.1.2.2` to surface the change for upgrades.
- The new fields are no-op defaults for databases missing the original recaptcha module and only exist to prevent view parsing errors.

### Testing
- Ran `python3 -m py_compile muk_web_theme/models/res_config_settings.py` and it succeeded.
- Ran `git diff --check` to ensure no whitespace or diff issues and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a701757f160832d810dcd0417aae30c)