### PR TITLE
Add parent/child project hierarchy and show tasks grouped by child project

### DIFF
--- a/sonha_du_an/models/project_project.py
+++ b/sonha_du_an/models/project_project.py
@@ -1,4 +1,5 @@
-from odoo import api, Command, fields, models, _, _lt
+from odoo import api, fields, models
+from odoo.exceptions import ValidationError
 
 
 class Project(models.Model):
@@ -10,4 +11,43 @@ class Project(models.Model):
     nguoi_qlda = fields.Many2one('res.users', string="Người QLDA")
     ngay_kt_da = fields.Date("Ngày kết thúc DA")
     ngay_kt_chinh_sua = fields.Date("Ngày kết thúc chỉnh sửa")
+    parent_du_an_id = fields.Many2one(
+        'project.project',
+        string="Dự án cha",
+        index=True,
+        ondelete='restrict',
+        domain="[('id', '!=', id)]",
+    )
+    du_an_con_ids = fields.One2many(
+        'project.project',
+        'parent_du_an_id',
+        string="Dự án con",
+    )
+    child_task_ids = fields.Many2many(
+        'project.task',
+        compute='_compute_child_task_ids',
+        string="Nhiệm vụ theo dự án con",
+    )
+    is_parent_du_an = fields.Boolean(
+        string="Là dự án cha",
+        compute='_compute_is_parent_du_an',
+    )
 
+    @api.depends('du_an_con_ids')
+    def _compute_is_parent_du_an(self):
+        for project in self:
+            project.is_parent_du_an = bool(project.du_an_con_ids)
+
+    @api.depends('du_an_con_ids.task_ids')
+    def _compute_child_task_ids(self):
+        for project in self:
+            project.child_task_ids = project.du_an_con_ids.mapped('task_ids')
+
+    @api.constrains('parent_du_an_id')
+    def _check_parent_du_an_id(self):
+        for project in self:
+            parent = project.parent_du_an_id
+            while parent:
+                if parent == project:
+                    raise ValidationError("Dự án cha/con không được tạo vòng lặp.")
+                parent = parent.parent_du_an_id

--- a/sonha_du_an/models/project_task.py
+++ b/sonha_du_an/models/project_task.py
@@ -1,10 +1,23 @@
-from odoo import api, Command, fields, models, tools, SUPERUSER_ID, _, _lt
+from odoo import fields, models
 
 
 class Task(models.Model):
     _inherit = 'project.task'
 
-    cap = fields.Many2one('project.project', string="Cấp")
+    cap = fields.Many2one(
+        'project.project',
+        string="Dự án con",
+        related='project_id',
+        store=True,
+        readonly=False,
+    )
+    parent_du_an_id = fields.Many2one(
+        'project.project',
+        string="Dự án cha",
+        related='project_id.parent_du_an_id',
+        store=True,
+        readonly=True,
+    )
     noi_dung_cv = fields.Text("Nội dung công việc")
     so_ngay_ht = fields.Float("Số ngày hoàn thành")
     ngay_bat_dau = fields.Date("Ngày bắt đầu")
@@ -12,4 +25,3 @@ class Task(models.Model):
     ngay_hoan_thanh = fields.Date("Ngày hoàn thành")
     ns_lam = fields.Many2one('res.users', string="NS làm")
     chu_so_huu = fields.Many2one('res.users', string="Chủ sở hữu")
-

--- a/sonha_du_an/views/nhap_lieu_du_an_views.xml
+++ b/sonha_du_an/views/nhap_lieu_du_an_views.xml
@@ -11,6 +11,7 @@
                             <field name="so_du_an"/>
                             <field name="group_du_an"/>
                             <field name="name"/>
+                            <field name="parent_du_an_id"/>
                             <field name="noi_dung"/>
                         </group>
                         <group>
@@ -20,10 +21,50 @@
                         </group>
                     </group>
                     <notebook>
-                        <page string="Nhập nhiệm vụ">
-                            <field name="task_ids" string="">
+                        <page string="Dự án con" name="du_an_con">
+                            <field name="du_an_con_ids" context="{'default_parent_du_an_id': id}">
                                 <tree editable="bottom">
-                                    <field name="cap"/>
+                                    <field name="so_du_an"/>
+                                    <field name="group_du_an"/>
+                                    <field name="name" string="Tên dự án con"/>
+                                    <field name="nguoi_qlda"/>
+                                    <field name="ngay_kt_da"/>
+                                    <field name="ngay_kt_chinh_sua"/>
+                                </tree>
+                                <form string="Dự án con">
+                                    <sheet>
+                                        <group>
+                                            <field name="parent_du_an_id" readonly="1"/>
+                                            <field name="name" string="Tên dự án con"/>
+                                            <field name="so_du_an"/>
+                                            <field name="group_du_an"/>
+                                            <field name="noi_dung"/>
+                                        </group>
+                                        <notebook>
+                                            <page string="Nhiệm vụ của dự án con">
+                                                <field name="task_ids" context="{'default_project_id': id}">
+                                                    <tree editable="bottom">
+                                                        <field name="name" string="Tên nhiệm vụ"/>
+                                                        <field name="noi_dung_cv"/>
+                                                        <field name="so_ngay_ht"/>
+                                                        <field name="ngay_bat_dau"/>
+                                                        <field name="ngay_ket_thuc"/>
+                                                        <field name="ngay_hoan_thanh"/>
+                                                        <field name="ns_lam"/>
+                                                        <field name="chu_so_huu"/>
+                                                    </tree>
+                                                </field>
+                                            </page>
+                                        </notebook>
+                                    </sheet>
+                                </form>
+                            </field>
+                        </page>
+                        <page string="Nhiệm vụ theo dự án con" name="nhiem_vu_theo_du_an_con">
+                            <field name="child_task_ids" readonly="1" context="{'group_by': 'project_id'}">
+                                <tree>
+                                    <field name="project_id" string="Dự án con"/>
+                                    <field name="name" string="Tên nhiệm vụ"/>
                                     <field name="noi_dung_cv"/>
                                     <field name="so_ngay_ht"/>
                                     <field name="ngay_bat_dau"/>
@@ -31,9 +72,9 @@
                                     <field name="ngay_hoan_thanh"/>
                                     <field name="ns_lam"/>
                                     <field name="chu_so_huu"/>
-                              </tree>
-                          </field>
-                      </page>
+                                </tree>
+                            </field>
+                        </page>
                     </notebook>
                 </sheet>
             </form>
@@ -46,9 +87,10 @@
         <field name="arch" type="xml">
             <tree string="Nhập liệu dự án">
                 <field name="so_du_an"/>
-                    <field name="group_du_an"/>
-                    <field name="name"/>
-                    <field name="noi_dung"/>
+                <field name="group_du_an"/>
+                <field name="name"/>
+                <field name="parent_du_an_id"/>
+                <field name="noi_dung"/>
                     <field name="nguoi_qlda"/>
                     <field name="ngay_kt_da"/>
                     <field name="ngay_kt_chinh_sua"/>
@@ -60,6 +102,7 @@
             <field name="name">Nhập liệu dự án</field>
             <field name="type">ir.actions.act_window</field>
             <field name="res_model">project.project</field>
+            <field name="domain">[('parent_du_an_id', '=', False)]</field>
             <field name="view_ids" eval="[(5, 0, 0),
                 (0, 0, {'view_mode': 'tree', 'view_id': ref('view_nhap_lieu_du_an_tree')}),
                 (0, 0, {'view_mode': 'form', 'view_id': ref('view_nhap_lieu_du_an_form')})]"/>


### PR DESCRIPTION
### Motivation
- Introduce a parent/child project structure so projects can be organized as parent projects with multiple child projects. 
- Ensure tasks are displayed and managed according to their child project so the project view matches the requested hierarchy. 
- Provide UI changes so users can create child projects and see child-project tasks directly from the parent project form. 

### Description
- Add new project fields on `project.project`: `parent_du_an_id`, `du_an_con_ids`, `child_task_ids`, and `is_parent_du_an`, plus computed methods and a constraint to prevent parent/child cycles. 
- Update `project.task` to relate `cap` to `project_id` and add a `parent_du_an_id` related to `project_id.parent_du_an_id` so a task knows its child and parent project contexts. 
- Modify the project form view `sonha_du_an/views/nhap_lieu_du_an_views.xml` to include a "Dự án con" notebook with inline child-project creation and a per-child "Nhiệm vụ của dự án con" task list, plus a "Nhiệm vụ theo dự án con" tab that aggregates tasks grouped by child project. 
- Narrow the action for the project entry (`action_nhap_lieu_du_an`) to display top-level parent projects by adding a domain `['parent_du_an_id', '=', False]`. 

### Testing
- `python3 -m py_compile sonha_du_an/models/project_project.py sonha_du_an/models/project_task.py` ran and succeeded. 
- XML structure for `sonha_du_an/views/nhap_lieu_du_an_views.xml` was validated with `xml.etree.ElementTree` parsing and succeeded. 
- `git diff --check` was run and reported no whitespace/patch errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a87c21f4e5c832db3fb9678a79d05bb)